### PR TITLE
Allow clients to configure when a refresh token expires

### DIFF
--- a/synapse/rest/client/login.py
+++ b/synapse/rest/client/login.py
@@ -598,7 +598,19 @@ class RefreshTokenServlet(RestServlet):
         if self.refreshable_access_token_lifetime is not None:
             access_valid_until_ms = now + self.refreshable_access_token_lifetime
         refresh_valid_until_ms = None
-        if self.refresh_token_lifetime is not None:
+
+        custom_refresh_token_lifetime = refresh_submission.get(
+            "com.famedly.refresh_token_lifetime_ms"
+        )
+        if custom_refresh_token_lifetime is not None:
+            if not isinstance(custom_refresh_token_lifetime, int):
+                raise SynapseError(
+                    400,
+                    "Invalid param: com.famedly.refresh_token_lifetime_ms",
+                    Codes.INVALID_PARAM,
+                )
+            refresh_valid_until_ms = now + custom_refresh_token_lifetime
+        elif self.refresh_token_lifetime is not None:
             refresh_valid_until_ms = now + self.refresh_token_lifetime
 
         (


### PR DESCRIPTION
This allows clients to pass an extra parameter when refreshing a token, which overrides the configured refresh token timeout in the Synapse config. This allows a client to opt into a shorter (or longer) lifetime for their refresh token, which could be used to sign out web sessions with a specific timeout.

Open questions are mostly if there should be a maximum refresh token lifetime someone could configure and if this should also be configurable on login. The latter doesn't seem as necessary, since a client can just refresh immediately after login (although that is racy).

Once we figure out a nice behaviour for this, we should also write an MSC. For now this is just an experiment.