### PR TITLE
max refresh token duration

### DIFF
--- a/synapse/config/registration.py
+++ b/synapse/config/registration.py
@@ -229,6 +229,14 @@ class RegistrationConfig(Config):
                     " exceeds `session_lifetime`!"
                 )
 
+        max_refresh_token_lifetime = config.get(
+            "famedly_maximum_refresh_token_lifetime", "160d"
+        )
+
+        if max_refresh_token_lifetime is not None:
+            max_refresh_token_lifetime = self.parse_duration(max_refresh_token_lifetime)
+        self.famedly_maximum_refresh_token_lifetime: int = max_refresh_token_lifetime
+
         # The fallback template used for authenticating using a registration token
         self.registration_token_template = self.read_template("registration_token.html")
 

--- a/synapse/rest/client/login.py
+++ b/synapse/rest/client/login.py
@@ -589,6 +589,9 @@ class RefreshTokenServlet(RestServlet):
             hs.config.registration.refreshable_access_token_lifetime
         )
         self.refresh_token_lifetime = hs.config.registration.refresh_token_lifetime
+        self.famedly_maximum_refresh_token_lifetime = (
+            hs.config.registration.famedly_maximum_refresh_token_lifetime
+        )
 
     async def on_POST(self, request: SynapseRequest) -> Tuple[int, JsonDict]:
         refresh_submission = parse_json_object_from_request(request)
@@ -614,7 +617,10 @@ class RefreshTokenServlet(RestServlet):
                     "Invalid param: com.famedly.refresh_token_lifetime_ms",
                     Codes.INVALID_PARAM,
                 )
-            refresh_valid_until_ms = now + custom_refresh_token_lifetime
+            refresh_valid_until_ms = now + min(
+                custom_refresh_token_lifetime,
+                self.famedly_maximum_refresh_token_lifetime,
+            )
         elif self.refresh_token_lifetime is not None:
             refresh_valid_until_ms = now + self.refresh_token_lifetime
 

--- a/tests/rest/client/test_auth.py
+++ b/tests/rest/client/test_auth.py
@@ -993,6 +993,79 @@ class RefreshAuthTests(unittest.HomeserverTestCase):
 
     @override_config(
         {
+            "refreshable_access_token_lifetime": "1m",
+            "refresh_token_lifetime": "2m",
+            "famedly_maximum_refresh_token_lifetime": "10m",
+        }
+    )
+    def test_custom_refresh_token_expiry_maximum(self) -> None:
+        """
+        The client might override the refresh token lifetime using the custom com.famedly.refresh_token_lifetime_ms parameter. Ensure we clamp to the maximum.
+        """
+
+        def use_custom_refresh_token(refresh_token: str) -> FakeChannel:
+            """
+            Helper that makes a request to use a refresh token with a custom lifetime (30 minutes).
+            """
+            return self.make_request(
+                "POST",
+                "/_matrix/client/v3/refresh",
+                {
+                    "refresh_token": refresh_token,
+                    "com.famedly.refresh_token_lifetime_ms": 30 * 60 * 1000,
+                },
+            )
+
+        body = {
+            "type": "m.login.password",
+            "user": "test",
+            "password": self.user_pass,
+            "refresh_token": True,
+        }
+        login_response = self.make_request(
+            "POST",
+            "/_matrix/client/r0/login",
+            body,
+        )
+        self.assertEqual(login_response.code, HTTPStatus.OK, login_response.result)
+        refresh_token1 = login_response.json_body["refresh_token"]
+
+        # refresh immediately to set custom expiry time
+        refresh_response = use_custom_refresh_token(refresh_token1)
+        self.assertEqual(refresh_response.code, HTTPStatus.OK, refresh_response.result)
+        self.assertIn(
+            "refresh_token",
+            refresh_response.json_body,
+            "No new refresh token returned after refresh.",
+        )
+        refresh_token2 = refresh_response.json_body["refresh_token"]
+
+        # Advance 179 seconds in the future (just shy of 3 minutes)
+        self.reactor.advance(179.0)
+
+        # Refresh our session. The refresh token should still JUST be valid right now.
+        # By doing so, we get a new access token and a new refresh token.
+        refresh_response = use_custom_refresh_token(refresh_token2)
+        self.assertEqual(refresh_response.code, HTTPStatus.OK, refresh_response.result)
+        self.assertIn(
+            "refresh_token",
+            refresh_response.json_body,
+            "No new refresh token returned after refresh.",
+        )
+        refresh_token3 = refresh_response.json_body["refresh_token"]
+
+        # Advance 610 seconds in the future (just a bit more than 10 minutes)
+        self.reactor.advance(610.0)
+
+        # Try to refresh our session, but instead notice that the refresh token is
+        # not valid (it just expired).
+        refresh_response = use_custom_refresh_token(refresh_token3)
+        self.assertEqual(
+            refresh_response.code, HTTPStatus.FORBIDDEN, refresh_response.result
+        )
+
+    @override_config(
+        {
             "refreshable_access_token_lifetime": "2m",
             "refresh_token_lifetime": "2m",
             "session_lifetime": "3m",


### PR DESCRIPTION
This amends 05b8fc15fcee3bebf27ad8b6e8f90868e5661b47.

You can now specify a maximum duration for the refresh token lifetime to be used with the custom `com.famedly.refresh_token_lifetime_ms` parameter. This clamps any values passed via the API to be lower or equal of this maximum specified via
`famedly_maximum_refresh_token_lifetime` in the config.

Fixes https://github.com/famedly/product-management/issues/2827