### PR TITLE
chore: add on_upgrade_room() to third_party_event_rules ModuleApi

### DIFF
--- a/synapse/handlers/room.py
+++ b/synapse/handlers/room.py
@@ -220,6 +220,8 @@ class RoomCreationHandler:
         if old_room is None:
             raise NotFoundError("Unknown room id %s" % (old_room_id,))
 
+        await self._third_party_event_rules.on_upgrade_room(requester, new_version)
+
         new_room_id = self._generate_room_id()
 
         # Try several times, it could fail with PartialStateConflictError

--- a/synapse/module_api/__init__.py
+++ b/synapse/module_api/__init__.py
@@ -117,6 +117,7 @@ from synapse.module_api.callbacks.third_party_event_rules_callbacks import (
     ON_PROFILE_UPDATE_CALLBACK,
     ON_REMOVE_USER_THIRD_PARTY_IDENTIFIER_CALLBACK,
     ON_THREEPID_BIND_CALLBACK,
+    ON_UPGRADE_ROOM_CALLBACK,
     ON_USER_DEACTIVATION_STATUS_CHANGED_CALLBACK,
 )
 from synapse.push.httppusher import HttpPusher
@@ -385,6 +386,7 @@ class ModuleApi:
         on_remove_user_third_party_identifier: Optional[
             ON_REMOVE_USER_THIRD_PARTY_IDENTIFIER_CALLBACK
         ] = None,
+        on_upgrade_room: Optional[ON_UPGRADE_ROOM_CALLBACK] = None,
     ) -> None:
         """Registers callbacks for third party event rules capabilities.
 
@@ -403,6 +405,7 @@ class ModuleApi:
             on_threepid_bind=on_threepid_bind,
             on_add_user_third_party_identifier=on_add_user_third_party_identifier,
             on_remove_user_third_party_identifier=on_remove_user_third_party_identifier,
+            on_upgrade_room=on_upgrade_room,
         )
 
     def register_presence_router_callbacks(


### PR DESCRIPTION
Called in the process of upgrading a room, provides access to the `Requester` object for data about the requesting user, and access to the `RoomVersion` object for data about the requested new version for the room.

Returns nothing, denials should raise a `SynapseError` with appropriate codes and messages that will be returned to the client. Multiple modules may implement this callback, first one that raises an Exception denies further processing of the upgrade to the room
