### PR TITLE
fix: Add is_requester_admin parameter to upgrade room callback

### DIFF
--- a/synapse/handlers/room.py
+++ b/synapse/handlers/room.py
@@ -220,7 +220,18 @@ class RoomCreationHandler:
         if old_room is None:
             raise NotFoundError("Unknown room id %s" % (old_room_id,))
 
-        await self._third_party_event_rules.on_upgrade_room(requester, new_version)
+        if (
+            self._server_notices_mxid is not None
+            and user_id == self._server_notices_mxid
+        ):
+            # allow the server notices mxid to create rooms
+            is_requester_admin = True
+        else:
+            is_requester_admin = await self.auth.is_server_admin(requester)
+
+        await self._third_party_event_rules.on_upgrade_room(
+            requester, new_version, is_requester_admin=is_requester_admin
+        )
 
         new_room_id = self._generate_room_id()
 

--- a/synapse/module_api/callbacks/third_party_event_rules_callbacks.py
+++ b/synapse/module_api/callbacks/third_party_event_rules_callbacks.py
@@ -55,7 +55,7 @@ ON_USER_DEACTIVATION_STATUS_CHANGED_CALLBACK = Callable[[str, bool, bool], Await
 ON_THREEPID_BIND_CALLBACK = Callable[[str, str, str], Awaitable]
 ON_ADD_USER_THIRD_PARTY_IDENTIFIER_CALLBACK = Callable[[str, str, str], Awaitable]
 ON_REMOVE_USER_THIRD_PARTY_IDENTIFIER_CALLBACK = Callable[[str, str, str], Awaitable]
-ON_UPGRADE_ROOM_CALLBACK = Callable[[Requester, RoomVersion], Awaitable]
+ON_UPGRADE_ROOM_CALLBACK = Callable[[Requester, RoomVersion, bool], Awaitable]
 
 
 def load_legacy_third_party_event_rules(hs: "HomeServer") -> None:
@@ -605,17 +605,18 @@ class ThirdPartyEventRulesModuleApiCallbacks:
                 )
 
     async def on_upgrade_room(
-        self, requester: Requester, room_version: RoomVersion
+        self, requester: Requester, room_version: RoomVersion, is_requester_admin: bool
     ) -> None:
         """Intercept requests to upgrade a room to maybe deny it (via an exception).
 
         Args:
             requester
             room_version: The RoomVersion requested for the upgrade.
+            is_requester_admin: If the requester is an admin
         """
         for callback in self._on_upgrade_room_callbacks:
             try:
-                await callback(requester, room_version)
+                await callback(requester, room_version, is_requester_admin)
             except Exception as e:
                 logger.exception(
                     "Failed to run module API callback %s: %s", callback, e


### PR DESCRIPTION
This is for consistency with the room create API.