### PR TITLE
chore: Split docker file into two, one just for versions of Synapse, and another for the Famedly modules layered on top

### DIFF
--- a/.github/workflows/docker-famedly.yml
+++ b/.github/workflows/docker-famedly.yml
@@ -1,20 +1,73 @@
 ---
+# Build the Community Edition of Synapse, then build the Famedly Edition on top. Push
+# both to their respective registries.
+
 name: Docker
 
 on:
   push:
     tags: ["v*.*.*_*"]
+  workflow_dispatch:
+    inputs:
+      tags:
+        description: "Tag for the docker image"
+        type: string
+        required: true
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  docker:
-    uses: famedly/github-workflows/.github/workflows/docker.yml@main
+  community-build:
+    # Since this will upload to ghcr.io, all we need is the github token. That is
+    # automatically passed into the workflow. This workflow is pinned to this branch so
+    # the support for including a namespace for the docker image name does not break
+    # digest merging for multiple architectures.
+    uses: famedly/github-workflows/.github/workflows/docker.yml@jason-docker-namespace
+    with:
+      push: ${{ github.event_name != 'pull_request' }} # Always build, don't publish on pull requests
+      registry: ghcr.io
+      image_name: famedly/synapse
+      file: docker/Dockerfile
+      # tag our new base image. If given a git tag of(as an example): "v1.234.5_6", this will
+      # break down into a docker tag of "v1.234.5" and "v1.234.5_6". As the suffix is incremented
+      # in future builds, this will make the base build sha change  and can potentially trigger
+      # "updated image" notifications(or some such) for the general public that would
+      # not actually have tangible updates.
+      # This will need to be sorted in the future, but I am not certain how yet. I would
+      # prefer not having suffix appended version for the community edition.
+      #
+      # Disable "latest" for now. It is enabled by default from the 'auto' functionality of flavors used
+      # when the tag is based on(in this case) a pattern and requires no explicit enablement.
+      # Allow for workflow_dispatch to create a docker image tagged with a custom tag.
+      # Use the full sha ref here, then we can borrow the Github context to reference
+      # it for the production-build below
+      tags: |
+        type=match,group=1,pattern=(v\d+.\d+.\d+)_\d+
+        type=match,group=1,pattern=(v\d+.\d+.\d+_\d+)
+        type=raw,value={{ inputs.tags }},enable=${{ github.event_name == 'workflow_dispatch'}}
+        type=sha,format=long
+      flavor: latest=false
+
+  production-build:
+    if: ${{ !cancelled() && !failure() }} # Allow for stopping the build job
+    needs:
+      - community-build
+    uses: famedly/github-workflows/.github/workflows/docker.yml@jason-docker-namespace
     with:
       push: ${{ github.event_name != 'pull_request' }} # Always build, don't publish on pull requests
       registry_user: famedly-ci
       registry: docker-oss.nexus.famedly.de
       image_name: synapse
-      file: docker/Dockerfile
+      file: docker/Dockerfile-famedly
+      # Notice that there is a leading 'sha-' in front of the actual sha, as that is
+      # how the docker meta action produces that tag.
+      build_args: "SYNAPSE_VERSION=sha-${{ github.sha }}"
+      # tag the production image used for famedly deployments.
+      # Allow for workflow_dispatch to create a docker image tagged with a custom tag.
       tags: |
-        type=match,group=1,pattern=(v\d+.\d+.\d+)_\d+
         type=match,group=1,pattern=(v\d+.\d+.\d+_\d+)
+        type=raw,value={{ inputs.tags }},enable=${{ github.event_name == 'workflow_dispatch'}}
+      flavor: latest=false
     secrets: inherit

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -93,18 +93,6 @@ COPY --from=requirements /synapse/requirements.txt /synapse/
 RUN --mount=type=cache,target=/root/.cache/uv \
   uv pip install --prefix="/install" --no-deps -r /synapse/requirements.txt
 
-# Install famedly required addons
-
-RUN --mount=type=cache,target=/root/.cache/pip \
-  pip install setuptools \
-  && pip install --prefix="/install" --no-warn-script-location \
-    synapse-token-authenticator==0.11.0 \
-    matrix-synapse-ldap3 \
-    synapse-s3-storage-provider \
-    synapse-invite-checker==0.4.5 \
-    git+https://github.com/famedly/synapse-invite-policies.git@main \
-    git+https://github.com/famedly/synapse-domain-rule-checker.git@main
-
 # Copy over the rest of the synapse source code.
 COPY synapse /synapse/synapse/
 COPY rust /synapse/rust/
@@ -191,8 +179,8 @@ FROM docker.io/library/python:${PYTHON_VERSION}-slim-${DEBIAN_VERSION}
 ARG TARGETARCH
 
 LABEL org.opencontainers.image.url='https://matrix.org/docs/projects/server/synapse'
-LABEL org.opencontainers.image.documentation='https://github.com/element-hq/synapse/blob/master/docker/README.md'
-LABEL org.opencontainers.image.source='https://github.com/element-hq/synapse.git'
+LABEL org.opencontainers.image.documentation='https://github.com/famedly/synapse/blob/master/docker/README.md'
+LABEL org.opencontainers.image.source='https://github.com/famedly/synapse.git'
 LABEL org.opencontainers.image.licenses='AGPL-3.0-or-later'
 
 COPY --from=runtime-deps /install-${TARGETARCH} /

--- a/docker/Dockerfile-famedly
+++ b/docker/Dockerfile-famedly
@@ -1,0 +1,33 @@
+# syntax=docker/dockerfile:1
+
+# Synapse Token Authenticator
+ARG STA_VERSION=0.11.0
+# Synapse Invite Checker
+ARG SIC_VERSION=0.4.5
+
+ARG SYNAPSE_VERSION=latest
+
+FROM ghcr.io/famedly/synapse:$SYNAPSE_VERSION
+
+# Install Famedly required addons
+ARG STA_VERSION
+ARG SIC_VERSION
+
+# To avoid having to install git, pip install directly from the source repository using
+# it's auto generated zip file for the two non-pypa modules below.
+RUN --mount=type=cache,target=/root/.cache/pip \
+  pip install setuptools \
+  && pip install --no-warn-script-location \
+    synapse-token-authenticator==${STA_VERSION} \
+    matrix-synapse-ldap3 \
+    synapse-s3-storage-provider \
+    synapse-invite-checker==${SIC_VERSION} \
+    https://github.com/famedly/synapse-invite-policies/archive/refs/heads/main.zip \
+    https://github.com/famedly/synapse-domain-rule-checker/archive/refs/heads/main.zip
+
+EXPOSE 8008/tcp 8009/tcp 8448/tcp
+
+ENTRYPOINT ["/start.py"]
+
+HEALTHCHECK --start-period=5s --interval=15s --timeout=5s \
+  CMD curl -fSs http://localhost:8008/health || exit 1


### PR DESCRIPTION
We have one Dockerfile we use to build Synapse and the modules we want to use with it. Let's split the Dockerfile into two: one for just Synapse and one that overlays on top of Synapse and carries the modules we wish to include. This should help keep the interests each fulfills a little bit more separate.

Objectively, this should be drop-in and backward compatible for now.

The base Synapse image will be built and pushed to the ghcr.io registry, and the modules Dockerfile will find and use that to build the final image used by the internal Famedly image registry.

Git tags are still going to be used as the trigger to build the image. A workflow dispatch will be added that can simulate that behavior. The existing structure(semver?) is still mandatory.

The Synapse image pushed to the internal Famedly image registry receives 3 tags(this was previous behavior):
* "vX.Y.Z_A"
* "vX.Y.Z"
* "latest"

I believe only the first is actually used. And since this base version of Synapse that will end up on ghcr.io will have no need for that exact tag, it will be removed and only the last two will be added instead. The internal Famedly image registry tag<del>s will be unchanged at this time.</del> will only be the longer form version and not a latest. So:
ghcr.io will have:
* "vX.Y.Z"
* "latest"

and nexus will have:
* "vX.Y.Z_A"

NOTE: For now, this update means that any update to module versions needs to happen in the Dockerfile-famedly near the top