### PR TITLE
Introduce `Accept` headers for sending federation transactions

### DIFF
--- a/synapse/federation/transport/client.py
+++ b/synapse/federation/transport/client.py
@@ -252,6 +252,8 @@ class TransportLayerClient:
 
         path = _create_v1_path("/send/%s", transaction.transaction_id)
 
+        headers: Dict[bytes, List[bytes]] = {b"Accept": [b"application/json"]}
+
         return await self.client.put_json(
             transaction.destination,
             path=path,
@@ -262,6 +264,7 @@ class TransportLayerClient:
             # Sending a transaction should always succeed, if it doesn't
             # then something is wrong and we should backoff.
             backoff_on_all_error_codes=True,
+            headers=headers,
         )
 
     async def make_query(


### PR DESCRIPTION
This is currently not processed by the receiving end
