### PR TITLE
chore: Re-enable multiple job runners for unit tests

### DIFF
--- a/.github/workflows/famedly-tests.yml
+++ b/.github/workflows/famedly-tests.yml
@@ -206,7 +206,11 @@ jobs:
       matrix:
         job: ${{ fromJson(needs.calculate-test-jobs.outputs.trial_test_matrix) }}
     env:
+      # Both of these are used for the coverage system. TOP gives the directory that is
+      # the root of the source code, and COVERAGE_PROCESS_START points at the coverage
+      # settings file to use(which also enables multiprocess implicit mode for coverage.py)
       TOP: ${{ github.workspace }}
+      COVERAGE_PROCESS_START: ${{ github.workspace }}/.coveragerc
 
     steps:
       - uses: actions/checkout@v4
@@ -217,7 +221,7 @@ jobs:
         # 2. Expose the unix socket for postgres. This removes latency of using docker-proxy for connections.
         run: |
           docker run -d -p 5432:5432 \
-            --tmpfs /var/lib/postgres:rw,size=6144m \
+            --tmpfs /var/lib/postgresql/data:rw,size=6144m \
             --mount 'type=bind,src=/var/run/postgresql,dst=/var/run/postgresql' \
             -e POSTGRES_PASSWORD=postgres \
             -e POSTGRES_INITDB_ARGS="--lc-collate C --lc-ctype C --encoding UTF8" \
@@ -234,9 +238,9 @@ jobs:
         if: ${{ matrix.job.postgres-version }}
         timeout-minutes: 2
         run: until pg_isready -h localhost; do sleep 1; done
-      - run: python -m pip install --user coverage
-      - run: poetry run coverage run -m twisted.trial tests
-        # can't run parallel jobs as that breaks coverage
+      # coverage is already installed from the pyproject.toml file
+      - run: poetry run pip install coverage-enable-subprocess
+      - run: poetry run coverage run -m twisted.trial -j4 tests
         env:
           SYNAPSE_POSTGRES: ${{ matrix.job.database == 'postgres' || '' }}
           SYNAPSE_POSTGRES_HOST: /var/run/postgresql

--- a/.github/workflows/famedly-tests.yml
+++ b/.github/workflows/famedly-tests.yml
@@ -240,7 +240,7 @@ jobs:
         run: until pg_isready -h localhost; do sleep 1; done
       # coverage is already installed from the pyproject.toml file
       - run: poetry run pip install coverage-enable-subprocess
-      - run: poetry run coverage run -m twisted.trial -j4 tests
+      - run: poetry run coverage run -m twisted.trial -j6 tests
         env:
           SYNAPSE_POSTGRES: ${{ matrix.job.database == 'postgres' || '' }}
           SYNAPSE_POSTGRES_HOST: /var/run/postgresql


### PR DESCRIPTION
Fixes:
* famedly/product-management#2987

Twisted's trial unit test runners can be ran in parallel, thereby making use of additional system resources to "Get more stuff done". Unfortunately, that does not play nicely with the coverage systems in place by default. I tested a few potentials with the `--coverage` option Twisted provides, but it was incredibly slow(I believe in disk I/O specifically) and was not worth the effort. So, coverage.py it is.

[Coverage docs](https://coverage.readthedocs.io/en/latest/subprocess.html) about multiprocessing, which is not what Twisted actually uses

However, near the bottom of that page it lists a couple methods of implicitly starting the coverage routines with multiprocessing support, and that worked. I chose the 'implicit' method which actually has a python package to do the dirty work for us. It is `coverage-enable-subprocess 1.0`, but don't let the version number fool you; there is nothing that needs to be updated and it has existed for quite some time. Simple is best, in this case

Otherwise the trick was getting it to install for the unit tests without actually touching the poetry lock file, as version drift from when it was brought into Synapse has not aged well(apparently this is on the radar upstream?). I elected to have it install into the virtual environment that is produced for the trials

(Quick Note: coverage is going to be weird between PR's and main, as there are only 3 trial runs on PRs and main gets like 8 with different python versions. Still tho, this is much better times)