### PR TITLE
[TEST-do not merge]: Bump max backfill denied host count

### DIFF
--- a/synapse/handlers/federation.py
+++ b/synapse/handlers/federation.py
@@ -470,7 +470,7 @@ class FederationHandler:
 
             # Maximum number of contacted remote homeservers that can deny our
             # backfill request with 4xx codes before we give up.
-            max_denied_count = 5
+            max_denied_count = min(len(domains), 50)
 
             for dom in domains:
                 # We don't want to ask our own server for information we don't have


### PR DESCRIPTION
In the case of an code error response between 400 and 500, a counter is incremented. However, if the remote server is experiencing a state malfunction it may only think we are not in the room when we actually are. Perhaps another server in the room disagrees and will disclose room data for us. Try all the domains until 50 have been tried, then it is more likely of success.

### Pull Request Checklist

<!-- Please read https://element-hq.github.io/synapse/latest/development/contributing_guide.html before submitting your pull request -->

* [ ] Pull request is based on the develop branch
* [ ] Pull request includes a [changelog file](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#changelog). The entry should:
  - Be a short description of your change which makes sense to users. "Fixed a bug that prevented receiving messages from other servers." instead of "Moved X method from `EventStore` to `EventWorkerStore`.".
  - Use markdown where necessary, mostly for `code blocks`.
  - End with either a period (.) or an exclamation mark (!).
  - Start with a capital letter.
  - Feel free to credit yourself, by adding a sentence "Contributed by @github_username." or "Contributed by [Your Name]." to the end of the entry.
* [ ] [Code style](https://element-hq.github.io/synapse/latest/code_style.html) is correct
  (run the [linters](https://element-hq.github.io/synapse/latest/development/contributing_guide.html#run-the-linters))
