### PR TITLE
chore: Add workflow to build docker image on branches

### DIFF
--- a/.github/workflows/docker-pr-dev.yml
+++ b/.github/workflows/docker-pr-dev.yml
@@ -1,0 +1,79 @@
+# GitHub actions workflow to build and push base docker images for pull requests.
+name: Build Dev Docker Image on PR
+
+on:
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'Pull request number. Be sure to match it to the correct branch selected'
+        required: true
+        type: string
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  dev-build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    env:
+      IMAGE_NAME: synapse
+      REGISTRY_GHCR: ghcr.io
+      REGISTRY_NEXUS: docker-oss.nexus.famedly.de
+    steps:
+      - name: Validate pr_number_on_dispatch
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          if ! [[ "${{ github.event.inputs.pr_number }}" =~ ^[0-9]+$ ]]; then
+            echo "Error: pr_number must be numeric."
+            exit 1
+          fi
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Nexus
+        uses: docker/login-action@v3
+        with:
+          registry: ${{env.REGISTRY_NEXUS}}
+          username: famedly-ci
+          password: ${{ secrets.registry_password }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.REGISTRY_GHCR }}/famedly/${{ env.IMAGE_NAME }}
+            ${{ env.REGISTRY_NEXUS }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,enable=${{ github.event_name == 'workflow_dispatch' }},value=pr-${{ github.event.inputs.pr_number }}
+            type=ref,enable=${{ github.event_name == 'pull_request' }},event=pr
+          flavor: latest=false
+
+      - name: Build and push Docker image (amd64 only)
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          platforms: linux/amd64
+          file: docker/Dockerfile
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          sbom: true


### PR DESCRIPTION
## Build synapse docker images also for branches [#2984](https://github.com/famedly/product-management/issues/2984)

My understanding so far is that we only need to generate the base image.
If the PR was generated by org user, the image with tag `pr-[pr number]` will be available on both ghcr and nexus.
For `workflow_dispatch` trigger, it requires manual `pr_number` input.
With current setting, external contributors need approval to run any workflow.
Even their prs got the approval to run the workflow, the write permission is limited and won't able to push the images to any of the registry.
So these workflows are limited to the internal members who have the write permission to our registry.

## Need clarification
1. As I mentioned above, the changes in this PR are limited to the internal members who have proper write permission. Would this meet the requirements of this task? or do we need to find a way to give externals the write permission later?
2. Do we also want to build famedly image that contains our modules? what would the expected workflow here?
3. Future improvements:
 - we receive pr number as manual input, but later we can do `gh search prs --head <branch_name> --json number --state open` and retrieve pr number automatically.
 - There is no official retention policy to delete old/unused images. Instead we can use this [github actions](https://github.com/snok/container-retention-policy) that regularly clean up dev images, but this is not allowed within our org.
- Should we maintaining our own `famedly-changes.rst` file or something?

## Pull Request Checklist

- [x] When opening a PR or pushing to a branch, a container image with a tag named ~~after the branch~~ pr number should be built.
- [x] This should not be abusable by external contributions.
- [x] Require explicit approval to push such nightly images by the matrix team. (current status: Externals can run workflow with approval but can't push images to any registry)
- [x] triggering event should be pull_request, so that random branches from random people won't run our docker build system. Probably should only build the image but not push it for outside contributions.
- [x] ~~Check the authoring user for membership in the organization~~ to use for deciding if 'pushing' the image is required (current status: pr from forks can't run the workflow without permission according to repo settings, so no need to check membership during the workflow)
- [x] The branch image should be accessible in our nexus.
- [x] The branch image should be accessible in ghcr.
- [x] Tag name should include user or organization namespace from the source repo and tag name should include ~~"nightly"~~ or "branch" as a prefix to differentiate them from stable images. The tag will be `pr-[pr_number]`
- [x] Remember to escape special characters in tag names.
- [x] No git tag versioning for this to prevent confusion with releases.
- [x] The github action for the docker metadata should take care to strip-out/escape incorrect/ineligible characters. Looks like the that same github action has some interesting/useful bits attached to it's [ref](https://github.com/docker/metadata-action?tab=readme-ov-file#typeref) type filter for the tag name.
- [x] create only amd64 runner

