### PR TITLE
example 2 for gedisa missing messages

### DIFF
--- a/synapse/handlers/pagination.py
+++ b/synapse/handlers/pagination.py
@@ -579,10 +579,20 @@ class PaginationHandler:
             ):
                 # Historical Note: There used to be a check here for if backfill was
                 # successful or not
+                logger.info("JASON: found big gap: %r", found_big_gap)
+                logger.info(
+                    "JASON: missing_to_many_events: %r", missing_too_many_events
+                )
+                logger.info(
+                    "JASON: not_enough_events_to_fill_response: %r",
+                    not_enough_events_to_fill_response,
+                )
+                logger.info("JAsON: curr_topo token: %r", curr_topo)
                 await self.hs.get_federation_handler().maybe_backfill(
                     room_id,
                     curr_topo,
                     limit=pagin_config.limit,
+                    skip_calculating_backwards_extremities=True,
                 )
 
                 # Regardless if we backfilled or not, another worker or even a


### PR DESCRIPTION
One of two potential options. Unfinished
* The spec for [`/backfill`](https://spec.matrix.org/v1.11/server-server-api/#get_matrixfederationv1backfillroomid) requests says nothing about the response being a 'breadth-first, "depth" ordered search', unlike the 'breadth-first' requirement on [`/get_missing_events`](https://spec.matrix.org/v1.11/server-server-api/#post_matrixfederationv1get_missing_eventsroomid). 

* It also does not say that you have to use only an event preceding one you already have for the calculating the request, as Synapse does as an optimization([`get_backfill_points_in_room()`](https://github.com/famedly/synapse/blob/5c7d9732a974420eeeb3df1b0afe3fb78253c464/synapse/storage/databases/main/event_federation.py#L946) which looks for existing backwards extremities).

Combining these two approaches allows for expanding the result of a `/backfill` request to include 'sibling' events(what are these really called?) that would be at the same 'depth' but not necessarily linked by a successor event(such as what ties forward extremities together).

Two prong approach:
1. Remove the optimization that calculates the backfill request to start at known backwards extremities. This is technically wrong and needs to be adjusted slightly still. WIP
2. Adjust the backfill response to include potentially parallel branches that may exist that would not be normally included in a breadth-first depth based walk of the DAG. ATM, this only checks the original 'seed' event that is used in the original request and not 'siblings' of later events in a branch. Effectively retrieves any forward extremities that are 'siblings' of the 'seed' event


Notes on `get_backfill_points_in_room()`:
For our situation, the depth that is used to calculate the backfill point is based on the rooms `topological token`, which places it *just* before the join. This is pulled from the `/messages` request, so that it's response will include the join event. The `topo token` is therefore at the *invite*
* Invite is a backfill point
* Join is a successor event to the Invite
* filter if allowed to see the Join
* If yes, use the Invite