### PR TITLE
fix: await clock.sleep() calls

### DIFF
--- a/synapse/http/server.py
+++ b/synapse/http/server.py
@@ -337,7 +337,7 @@ class _AsyncResource(resource.Resource, metaclass=abc.ABCMeta):
                     callback_return = await self._async_render(request)
                 except LimitExceededError as e:
                     if e.pause:
-                        self._clock.sleep(e.pause)
+                        await self._clock.sleep(e.pause)
                     raise
 
                 if callback_return is not None:

--- a/synapse/storage/databases/main/deviceinbox.py
+++ b/synapse/storage/databases/main/deviceinbox.py
@@ -1026,7 +1026,7 @@ class DeviceInboxWorkerStore(SQLBaseStore):
 
             # We sleep a bit so that we don't hammer the database in a tight
             # loop first time we run this.
-            self._clock.sleep(1)
+            await self._clock.sleep(1)
 
     async def get_devices_with_messages(
         self, user_id: str, device_ids: StrCollection


### PR DESCRIPTION
Without this, LogContext gets lost whenever a 429 ratelimited request is hit. Found this in unit tests based on > 1.133.0 when ran with `-j30` locally and sometimes on Github CI.

```
synapse.access.http.fake - 463 - DEBUG - POST-458 - 127.0.0.4 - test - Received request: POST /_matrix/client/r0/account/password/email/requestToken
synapse.http.server - 129 - INFO - sentinel - <SynapseRequest at 0x747656210a50 method='POST' uri='/_matrix/client/r0/account/password/email/requestToken' clientproto='1.1' site='test'> SynapseError: 429 - Too Many Requests (rc_3pid_validation)
synapse.logging.context - 1003 - WARNING - sentinel - Calling defer_to_threadpool from sentinel context: metrics will be lost
synapse.logging.context - 91 - WARNING - sentinel - Expected logging context POST-458 was lost
```
```
synapse.http.server - 129 - INFO - sentinel - <SynapseRequest at 0x797f96242fd0 method='POST' uri='/_matrix/client/r0/account/3pid/email/requestToken' clientproto='1.1' site='test'> SynapseError: 429 - Too Many Requests (rc_3pid_validation)
synapse.logging.context - 1003 - WARNING - sentinel - Calling defer_to_threadpool from sentinel context: metrics will be lost
synapse.logging.context - 91 - WARNING - sentinel - Expected logging context POST-507 was lost
```
```
synapse.access.http.fake - 463 - DEBUG - POST-524 - 127.0.0.1 - test - Received request: POST /_matrix/client/unstable/org.matrix.msc4140/delayed_events/syd_NMSyxjjZYAnRtJaQnRib
synapse.http.server - 129 - INFO - sentinel - <SynapseRequest at 0x797f96467390 method='POST' uri='/_matrix/client/unstable/org.matrix.msc4140/delayed_events/syd_NMSyxjjZYAnRtJaQnRib' clientproto='1.1' site='test'> SynapseError: 429 - Too Many Requests (rc_delayed_event_mgmt)
synapse.logging.context - 1003 - WARNING - sentinel - Calling defer_to_threadpool from sentinel context: metrics will be lost
synapse.logging.context - 91 - WARNING - sentinel - Expected logging context POST-524 was lost
```
```
synapse.access.http.fake - 463 - DEBUG - POST-406 - 127.0.0.1 - test - Received request: POST /_matrix/client/unstable/org.matrix.msc4140/delayed_events/syd_tdteCbukfNXOuDllYOWZ
synapse.http.server - 129 - INFO - sentinel - <SynapseRequest at 0x78d05af90410 method='POST' uri='/_matrix/client/unstable/org.matrix.msc4140/delayed_events/syd_tdteCbukfNXOuDllYOWZ' clientproto='1.1' site='test'> SynapseError: 429 - Too Many Requests (rc_message)
synapse.logging.context - 1003 - WARNING - sentinel - Calling defer_to_threadpool from sentinel context: metrics will be lost
synapse.logging.context - 91 - WARNING - sentinel - Expected logging context POST-406 was lost
```
```
synapse.access.http.fake - 463 - DEBUG - POST-467 - 127.0.0.1 - test - Received request: POST /_matrix/client/r0/login
synapse.rest.client.login - 341 - INFO - POST-467 - Got login request with identifier: {'type': 'm.id.user', 'user': 'kermit'}, medium: None, address: None, user: None
synapse.http.server - 129 - INFO - sentinel - <SynapseRequest at 0x733a8c21a850 method='POST' uri='/_matrix/client/r0/login' clientproto='1.1' site='test'> SynapseError: 429 - Too Many Requests (rc_login.failed_attempts)
synapse.logging.context - 1003 - WARNING - sentinel - Calling defer_to_threadpool from sentinel context: metrics will be lost
synapse.logging.context - 91 - WARNING - sentinel - Expected logging context POST-467 was lost
```
```
synapse.access.http.fake - 463 - DEBUG - PUT-24 - 127.0.0.1 - test - Received request: PUT /_matrix/federation/v2/send_join/!MHESsvwWPfbwJXUagm:test/join1
...
synapse.federation.transport.server._base - 138 - DEBUG - PUT-24 - Request from other.example.com
synapse.util.ratelimitutils - 321 - DEBUG - PUT-24 - Ratelimit(other.example.com) [126397259186432]: len(self.request_times)=4
synapse.util.ratelimitutils - 354 - DEBUG - PUT-24 - Ratelimit(other.example.com) [126397259186432]: Processing req
synapse.util.ratelimitutils - 378 - DEBUG - PUT-24 - Ratelimit(other.example.com) [126397259186432]: Processed req
synapse.http.server - 129 - INFO - sentinel - <SynapseRequest at 0x72f527bab390 method='PUT' uri='/_matrix/federation/v2/send_join/!MHESsvwWPfbwJXUagm:test/join1' clientproto='1.1' site='test'> SynapseError: 429 - Too Many Requests (rc_joins_per_room)
synapse.logging.context - 1003 - WARNING - sentinel - Calling defer_to_threadpool from sentinel context: metrics will be lost
```
I am not certain how prevelant this may occur in production, but at the root is that a `sleep()` is backgrounded without the logging context being present. When the `sleep()` occurs, it is to be part of a tightlooping foil for requests that are being ratelimited. It may be that these requests are therefore...not ratelimited.

As a drive-by fix, there was another unawaited `sleep()` in the code base, fixed that one too