### PR TITLE
fix: Allow account deactivation even with disabled profile changes

### DIFF
--- a/synapse/handlers/profile.py
+++ b/synapse/handlers/profile.py
@@ -192,7 +192,9 @@ class ProfileHandler:
         if not by_admin and target_user != requester.user:
             raise AuthError(400, "Cannot set another user's displayname")
 
-        if not by_admin and not self.hs.config.registration.enable_set_displayname:
+        if (
+            not by_admin and not self.hs.config.registration.enable_set_displayname
+        ) and not (deactivation and new_displayname == ""):
             profile = await self.store.get_profileinfo(target_user)
             if profile.display_name:
                 raise SynapseError(
@@ -296,7 +298,9 @@ class ProfileHandler:
         if not by_admin and target_user != requester.user:
             raise AuthError(400, "Cannot set another user's avatar_url")
 
-        if not by_admin and not self.hs.config.registration.enable_set_avatar_url:
+        if (
+            not by_admin and not self.hs.config.registration.enable_set_avatar_url
+        ) and not (deactivation and new_avatar_url == ""):
             profile = await self.store.get_profileinfo(target_user)
             if profile.avatar_url:
                 raise SynapseError(

--- a/tests/handlers/test_profile.py
+++ b/tests/handlers/test_profile.py
@@ -33,6 +33,7 @@ from synapse.types import JsonDict, UserID
 from synapse.util import Clock
 
 from tests import unittest
+from tests.unittest import override_config
 
 
 class ProfileTestCase(unittest.HomeserverTestCase):
@@ -113,9 +114,8 @@ class ProfileTestCase(unittest.HomeserverTestCase):
             self.get_success(self.store.get_profile_displayname(self.frank))
         )
 
-    def test_set_my_name_if_disabled(self) -> None:
-        self.hs.config.registration.enable_set_displayname = False
-
+    @override_config({"enable_set_displayname": False})
+    def test_set_displayname_if_disabled(self) -> None:
         # Setting displayname for the first time is allowed
         self.get_success(self.store.set_profile_displayname(self.frank, "Frank"))
 
@@ -234,9 +234,8 @@ class ProfileTestCase(unittest.HomeserverTestCase):
             (self.get_success(self.store.get_profile_avatar_url(self.frank))),
         )
 
-    def test_set_my_avatar_if_disabled(self) -> None:
-        self.hs.config.registration.enable_set_avatar_url = False
-
+    @override_config({"enable_set_avatar_url": False})
+    def test_set_avatar_url_if_disabled(self) -> None:
         # Setting displayname for the first time is allowed
         self.get_success(
             self.store.set_profile_avatar_url(self.frank, "http://my.server/me.png")


### PR DESCRIPTION
Fixes famedly/product-management#3334

Although `displayname` and `avatar_url` were discussed, this does not touch the MSC4133 arbitrary profile fields. If you need this too, let me know