### PR TITLE
feat: add msc3911 config option

### DIFF
--- a/synapse/config/experimental.py
+++ b/synapse/config/experimental.py
@@ -588,3 +588,11 @@ class ExperimentalConfig(Config):
         # MSC4306: Thread Subscriptions
         # (and MSC4308: sliding sync extension for thread subscriptions)
         self.msc4306_enabled: bool = experimental.get("msc4306_enabled", False)
+
+        # MSC3911: Linking Media to Events
+        self.msc3911_enabled: bool = experimental.get("msc3911_enabled", False)
+
+        # Disable the current media create and upload endpoints
+        self.msc3911_unrestricted_media_upload_disabled: bool = experimental.get(
+            "msc3911_unrestricted_media_upload_disabled", False
+        )

--- a/synapse/rest/client/versions.py
+++ b/synapse/rest/client/versions.py
@@ -177,6 +177,10 @@ class VersionsRestServlet(RestServlet):
                     "uk.tcpip.msc4133": self.config.experimental.msc4133_enabled,
                     # MSC4155: Invite filtering
                     "org.matrix.msc4155": self.config.experimental.msc4155_enabled,
+                    # MSC3911: Linking Media to Events
+                    "org.matrix.msc3911": self.config.experimental.msc3911_enabled,
+                    # MSC3911: Unrestricted Media Upload
+                    "org.matrix.msc3911.unrestricted_media_upload_disabled": self.config.experimental.msc3911_unrestricted_media_upload_disabled,
                 },
             },
         )


### PR DESCRIPTION
# Linked Media MSC3911 AP 0: Config option for the MSC [#3352](https://github.com/famedly/product-management/issues/3352)

# Acceptance Criteria
- [x] 2 new experimental config options, `msc3911_enabled` and `msc3911_unrestricted_media_upload_disabled`
- [x] `msc3911_unrestricted_media_upload_disabled` should disable the current media **create** **and** **upload** endpoints
- [x] Tests for disabling the old endpoints
- [x] The msc should be exposed in the unstable features of the version endpoint.