### PR TITLE
AP2: New create and upload endpoints to create restricted media

### DIFF
--- a/synapse/rest/client/media.py
+++ b/synapse/rest/client/media.py
@@ -41,6 +41,8 @@ from synapse.media._base import (
 from synapse.media.media_repository import MediaRepository
 from synapse.media.media_storage import MediaStorage
 from synapse.media.thumbnailer import ThumbnailProvider
+from synapse.rest.media.create_resource import CreateResource
+from synapse.rest.media.upload_resource import UploadRestrictedResource
 from synapse.server import HomeServer
 from synapse.util.stringutils import parse_and_validate_server_name
 
@@ -284,3 +286,6 @@ def register_servlets(hs: "HomeServer", http_server: HttpServer) -> None:
     MediaConfigResource(hs).register(http_server)
     ThumbnailResource(hs, media_repo, media_repo.media_storage).register(http_server)
     DownloadResource(hs, media_repo).register(http_server)
+    if hs.config.experimental.msc3911_enabled:
+        CreateResource(hs, media_repo, restricted=True).register(http_server)
+        UploadRestrictedResource(hs, media_repo).register(http_server)


### PR DESCRIPTION
# Linked Media MSC3911 AP2: New create and upload endpoints to create restricted media [#3351](https://github.com/famedly/product-management/issues/3351)

For linking media, we need new endpoints to create restricted media files:
<img width="709" height="118" alt="Screenshot 2025-08-13 at 17 13 55" src="https://github.com/user-attachments/assets/88b43f60-bad9-4e8a-b451-1c3669d6398b" />
These are equivalent to the existing create and upload endpoints for media, but create restricted media in a pending state (until the media is attached). 

### Question
`get_local_media` function of `GET /_matrix/client/v1/media/download/{server_name}/{media_id}/{filename}` endpoint is updated to make sure resource is not accessible to others in pending state. However, I am not sure what to do with remote media case. 

# Acceptance criteria
- [x] The new endpoints are implemented and available, when the MSC is enabled.
- [x] ONLY the unstable endpoints are available. The stable urls should only be implemented, when the MSC is merged.
- [x] Appropriate tests to validate, that media created this way is actually in the pending state.