### PR TITLE
Famedly Release v1.135.2_2

### DIFF
--- a/.ci/scripts/calculate_builds.py
+++ b/.ci/scripts/calculate_builds.py
@@ -53,11 +53,12 @@ all_mod_pack_versions = {
     "mod011": {"sic-version": "0.4.6", "sta-version": "0.11.0"},
     "mod012": {"sic-version": "0.4.7", "sta-version": "0.11.0"},
     "mod013": {"sic-version": "0.4.7", "sta-version": "0.12.0"},
+    "mod014": {"sic-version": "0.4.8", "sta-version": "0.12.0"},
 }
 
 # Adjust this section to decide what gets built and layered on top
 # THIS IS THE SECTION TO EDIT, after you have added the new versions above
-current_mod_packs_to_build = ["mod004", "mod013"]
+current_mod_packs_to_build = ["mod004", "mod014"]
 
 generated_jobs: list[dict[str, Any]] = []
 for mod_pack_job in current_mod_packs_to_build:

--- a/.github/workflows/docker-famedly.yml
+++ b/.github/workflows/docker-famedly.yml
@@ -22,6 +22,7 @@ jobs:
     with:
       push: ${{ github.event_name != 'pull_request' }} # Always build, don't publish on pull requests
       registry: ghcr.io
+      registry_user: ${{ github.repository_owner }}
       image_name: famedly/synapse
       file: docker/Dockerfile
       # tag our new base image. If given a git tag of(as an example): "v1.234.5_6", this will
@@ -68,7 +69,7 @@ jobs:
     uses: famedly/github-workflows/.github/workflows/docker.yml@jason-docker-namespace
     with:
       push: ${{ github.event_name != 'pull_request' }} # Always build, don't publish on pull requests
-      registry_user: famedly
+      registry_user: ${{ vars.REGISTRY_USER }}
       registry:  registry.famedly.net/docker-oss
       image_name: synapse
       file: docker/Dockerfile-famedly

--- a/.github/workflows/docker-pr-dev.yml
+++ b/.github/workflows/docker-pr-dev.yml
@@ -42,8 +42,8 @@ jobs:
       - name: Login to Harbor
         uses: docker/login-action@v3
         with:
-          registry: ${{env.REGISTRY_HARBOR}}
-          username: famedly
+          registry: ${{ env.REGISTRY_HARBOR }}
+          username: ${{ vars.REGISTRY_USER }}
           password: ${{ secrets.registry_password }}
 
       - name: Login to GitHub Container Registry

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,10 @@ Two patched Synapse releases are now available:
 
 
 
+### Famedly additions for v1.135.2_2
+
+- chore: Update mod packs to include fixed invite checker `v0.4.8` (Jason Little)
+
 # Synapse 1.135.0 (2025-08-01)
 
 No significant changes since 1.135.0rc2.

--- a/docker/Dockerfile-famedly
+++ b/docker/Dockerfile-famedly
@@ -20,7 +20,6 @@ RUN --mount=type=cache,target=/root/.cache/pip \
   pip install setuptools \
   && pip install --no-warn-script-location \
     synapse-token-authenticator==${STA_VERSION} \
-    matrix-synapse-ldap3 \
     synapse-s3-storage-provider \
     synapse-invite-checker==${SIC_VERSION} \
     https://github.com/famedly/synapse-invite-policies/archive/refs/heads/main.zip \


### PR DESCRIPTION
## New version of Synapse
### `v1.135.2_1` -> `v1.135.2_2`

#### Famedly additions in this release:
- chore: Update mod packs to include fixed invite checker `v0.4.8` (Jason Little)