### PR TITLE
MSC3911: AP2 - Database preparations and storage helpers

### DIFF
--- a/synapse/storage/schema/__init__.py
+++ b/synapse/storage/schema/__init__.py
@@ -19,7 +19,7 @@
 #
 #
 
-SCHEMA_VERSION = 92  # remember to update the list below when updating
+SCHEMA_VERSION = 93  # remember to update the list below when updating
 """Represents the expectations made by the codebase about the database schema
 
 This should be incremented whenever the codebase changes its requirements on the
@@ -168,6 +168,12 @@ Changes in SCHEMA_VERSION = 91
 
 Changes in SCHEMA_VERSION = 92
     - Cleaned up a trigger that was added in #18260 and then reverted.
+
+Changes in SCHEMA_VERSION = 93
+    - Introduced new column for `local_media_repository` and `remote_media_cache` to
+      flag media as 'restricted'. Defaults to False
+    - Introduced new table, `media_attachments`, to hold restriction data based on
+      `server_name` and `media_id`.
 """
 
 

--- a/synapse/storage/schema/main/delta/93/01_media_attachment_tables.sql
+++ b/synapse/storage/schema/main/delta/93/01_media_attachment_tables.sql
@@ -1,0 +1,9 @@
+-- JSONB and the operators we use are compatible with both Postgres 9.5+ and SQLite 3.38.0+
+-- The UNIQUE constraint helps not only to insure there are never more than one grouping
+-- of restrictions for a given server_name/media_id combo, but also act as an index
+CREATE TABLE media_attachments (
+    server_name TEXT NOT NULL,
+    media_id TEXT NOT NULL,
+    restrictions_json JSONB NOT NULL,
+    UNIQUE (server_name, media_id)
+);

--- a/synapse/storage/schema/main/delta/93/01_media_restrictions.sql.postgres
+++ b/synapse/storage/schema/main/delta/93/01_media_restrictions.sql.postgres
@@ -1,0 +1,7 @@
+ALTER TABLE local_media_repository
+ADD COLUMN restricted BOOLEAN NOT NULL DEFAULT FALSE;
+
+ALTER TABLE remote_media_cache
+ADD COLUMN restricted BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- by using DEFAULT FALSE, the existing data should be backwards compatible

--- a/synapse/storage/schema/main/delta/93/01_media_restrictions.sql.sqlite
+++ b/synapse/storage/schema/main/delta/93/01_media_restrictions.sql.sqlite
@@ -1,0 +1,9 @@
+ALTER TABLE local_media_repository
+ADD COLUMN restricted INTEGER DEFAULT 0 CHECK (restricted IN (0, 1));
+
+ALTER TABLE remote_media_cache
+ADD COLUMN restricted INTEGER DEFAULT 0 CHECK (restricted IN (0, 1));
+
+ -- sqlite doesn't do booleans, integers is what you get
+ -- by using DEFAULT 0, the existing data should be backwards compatible
+ -- the CHECK enforces the data(equivalent of NOT NULL)

--- a/synapse/storage/schema/main/delta/93/02_media_attachment_tables.sql.postgres
+++ b/synapse/storage/schema/main/delta/93/02_media_attachment_tables.sql.postgres
@@ -1,0 +1,7 @@
+-- Postgres supports Generalized Inverted Indexes, which work well for JSON data.
+CREATE INDEX media_attachments_event_id_idx ON media_attachments USING GIN ((restrictions_json->'restrictions'->'event_id'));
+
+CREATE INDEX media_attachments_profile_user_id_idx ON media_attachments USING GIN ((restrictions_json->'restrictions'->'profile_user_id'));
+
+-- Unfortunately, SQLite does not support the same sort of index. The alternative would
+-- probably be an index on a generated column produced from the JSON at insertion time.

--- a/tests/rest/client/utils.py
+++ b/tests/rest/client/utils.py
@@ -607,6 +607,33 @@ class RestHelper:
 
         return channel.json_body
 
+    def create_media_id_v1(
+        self,
+        tok: str,
+        expect_code: int = HTTPStatus.OK,
+    ) -> JsonDict:
+        """Create the media ID that can be uploaded to later
+        Args:
+            tok: The user token to use during the upload
+            expect_code: The return code to expect from attempting to upload the media
+        """
+        path = "/_matrix/media/v1/create"
+        channel = make_request(
+            self.reactor,
+            self.site,
+            "POST",
+            path,
+            access_token=tok,
+        )
+
+        assert channel.code == expect_code, "Expected: %d, got: %d, resp: %r" % (
+            expect_code,
+            channel.code,
+            channel.result["body"],
+        )
+
+        return channel.json_body
+
     def whoami(
         self,
         access_token: str,

--- a/tests/storage/test_media.py
+++ b/tests/storage/test_media.py
@@ -1,0 +1,210 @@
+import io
+from typing import Dict
+
+from matrix_common.types.mxc_uri import MXCUri
+
+from twisted.test.proto_helpers import MemoryReactor
+from twisted.web.resource import Resource
+
+from synapse.api.errors import SynapseError
+from synapse.rest import admin
+from synapse.rest.client import login, media
+from synapse.server import HomeServer
+from synapse.storage.databases.main.media_repository import MediaRestrictions
+from synapse.types import JsonDict, UserID
+from synapse.util import Clock
+from synapse.util.stringutils import random_string
+
+from tests import unittest
+from tests.test_utils import SMALL_PNG
+
+
+class MediaAttachmentStorageTestCase(unittest.HomeserverTestCase):
+    """Test that storing and retrieving media restrictions works as expected"""
+
+    def prepare(
+        self, reactor: MemoryReactor, clock: Clock, homeserver: HomeServer
+    ) -> None:
+        self.store = homeserver.get_datastores().main
+        self.server_name = self.hs.config.server.server_name
+
+    def test_store_and_retrieve_media_restrictions_by_event_id(self) -> None:
+        event_id = "$random_event_id"
+        media_restrictions = {"restrictions": {"event_id": event_id}}
+        media_id = random_string(24)
+        self.get_success_or_raise(
+            self.store.set_media_restrictions(
+                self.server_name, media_id, media_restrictions
+            )
+        )
+
+        retrieved_restrictions = self.get_success_or_raise(
+            self.store.get_media_restrictions(self.server_name, media_id)
+        )
+        assert retrieved_restrictions is not None
+        assert retrieved_restrictions.event_id == event_id
+        assert retrieved_restrictions.profile_user_id is None
+
+    def test_store_and_retrieve_media_restrictions_by_profile_user_id(self) -> None:
+        user_id = UserID.from_string("@frank:test")
+        media_restrictions = {"restrictions": {"profile_user_id": user_id.to_string()}}
+        media_id = random_string(24)
+        self.get_success_or_raise(
+            self.store.set_media_restrictions(
+                self.server_name, media_id, media_restrictions
+            )
+        )
+
+        retrieved_restrictions = self.get_success_or_raise(
+            self.store.get_media_restrictions(self.server_name, media_id)
+        )
+        assert retrieved_restrictions is not None
+        assert retrieved_restrictions.event_id is None
+        assert retrieved_restrictions.profile_user_id == user_id
+
+    def test_retrieve_media_without_restrictions(self) -> None:
+        media_id = random_string(24)
+
+        retrieved_restrictions = self.get_success_or_raise(
+            self.store.get_media_restrictions(self.server_name, media_id)
+        )
+        assert retrieved_restrictions is None
+
+
+class MediaPendingAttachmentTestCase(unittest.HomeserverTestCase):
+    servlets = [
+        admin.register_servlets,
+        login.register_servlets,
+        media.register_servlets,
+    ]
+
+    def default_config(self) -> JsonDict:
+        config = super().default_config()
+        return config
+
+    def prepare(
+        self, reactor: MemoryReactor, clock: Clock, homeserver: HomeServer
+    ) -> None:
+        self.store = homeserver.get_datastores().main
+        self.server_name = self.hs.config.server.server_name
+
+        self.user = self.register_user("frank", "password")
+        self.tok = self.login("frank", "password")
+
+    def create_resource_dict(self) -> Dict[str, Resource]:
+        resources = super().create_resource_dict()
+        # The old endpoints are not loaded with the register_servlets above
+        resources["/_matrix/media"] = self.hs.get_media_repository_resource()
+        return resources
+
+    def test_setting_media_restriction_twice_errors(
+        self,
+    ) -> None:
+        """Setting media restrictions on a single piece of media TWICE is not allowed.
+        Test that it errors
+        """
+        upload_result = self.helper.upload_media(SMALL_PNG, tok=self.tok)
+        assert upload_result.get("content_uri") is not None
+
+        content_uri: str = upload_result["content_uri"]
+        # We can split the content_uri on the last "/" and the rest is the media_id
+        media_id = content_uri.rsplit("/", maxsplit=1)[1]
+
+        event_id = "$something_hashy_doesnt_matter"
+        media_restrictions = {"restrictions": {"event_id": event_id}}
+        self.get_success(
+            self.store.set_media_restrictions(
+                self.server_name, media_id, media_restrictions
+            )
+        )
+
+        existing_media_restrictions = self.get_success(
+            self.store.get_media_restrictions(
+                self.server_name,
+                media_id,
+            )
+        )
+        assert existing_media_restrictions is not None
+
+        self.get_failure(
+            self.store.set_media_restrictions(
+                self.server_name, media_id, media_restrictions
+            ),
+            SynapseError,
+        )
+
+
+class MediaAttachmentFlowTestCase(unittest.HomeserverTestCase):
+    servlets = [
+        admin.register_servlets,
+        login.register_servlets,
+        media.register_servlets,
+    ]
+
+    def prepare(
+        self, reactor: MemoryReactor, clock: Clock, homeserver: HomeServer
+    ) -> None:
+        self.store = homeserver.get_datastores().main
+        self.server_name = self.hs.config.server.server_name
+        self.media_repo = self.hs.get_media_repository()
+
+        self.user = self.register_user("frank", "password")
+        self.tok = self.login("frank", "password")
+
+    def create_resource_dict(self) -> Dict[str, Resource]:
+        resources = super().create_resource_dict()
+        # The old endpoints are not loaded with the register_servlets above
+        resources["/_matrix/media"] = self.hs.get_media_repository_resource()
+        return resources
+
+    def create_media(self) -> MXCUri:
+        content = io.BytesIO(SMALL_PNG)
+        content_uri = self.get_success(
+            self.media_repo.create_or_update_content(
+                "image/png",
+                "test_png_upload",
+                content,
+                67,
+                UserID.from_string("@user_id:whatever.org"),
+                restricted=True,
+            )
+        )
+        return content_uri
+
+    def test_flow(self) -> None:
+        """Example flow of storing media data and retrieving it from the database"""
+        # Create media by using create_or_update_content() helper. This will likely be
+        # on the new `/create` and `/upload` endpoints for msc3911.
+
+        # set actual restrictions using storage method `set_media_restrictions()`
+
+        # use `get_local_media()` to retrieve the data
+
+        mxc_uri = self.create_media()
+        media_id = mxc_uri.media_id
+        assert media_id
+
+        local_media_object = self.get_success(self.store.get_local_media(media_id))
+        assert local_media_object
+        assert local_media_object.restricted is True
+
+        # This one is why we are here, it doesn't exist yet
+        assert local_media_object.attachments is None
+
+        event_id = "$event_id_hash_goes_here"
+        self.get_success(
+            self.store.set_media_restrictions(
+                self.server_name,
+                media_id,
+                {"restrictions": {"event_id": event_id}},
+            )
+        )
+
+        # Retrieve the data and make sure the restrictions are there
+        local_media_object = self.get_success(self.store.get_local_media(media_id))
+        assert local_media_object
+
+        assert local_media_object.restricted is True
+        # This one is why we are here, it's here this time. Yay!
+        assert isinstance(local_media_object.attachments, MediaRestrictions)
+        assert local_media_object.attachments.event_id == event_id


### PR DESCRIPTION
Create a new table `media_attachments` to contain

| `server_name` | `media_id` | `restrictions_json` |
|--------|--------|--------|
| test.com | Skckel3slSlkdhg | '{"restrictions": {"event_id": "$event_id_hash"}' |
| test.com | jshAy7DjvjsLE83 | '{"restrictions": {"profile_user_id": "@jason-famedly:server.com"}' | 

Add a new column to `remote_media_cache` for `restricted` boolean values

Add a new column to `local_media_repository` for `restricted` for boolean values

Test series added at `tests.storage.test_media`

* [x] Update `LocalMedia` to have a `restricted` boolean object
* [x] Update `RemoteMedia` to have a `restricted` boolean object
* Add new database schema files to add new columns/tables:
  * [x] Update `local_media_repository` to have new columns from description above
  * [x] Update `remote_media_cache` to have new columns from description above
  * [x] Create new table `media_attachments` based on table above
* [x] Create new `MediaRestrictions` object to contain an `event_id` and `profile_user_id`. Do we want this to be validated at this level or have it be validated before creation of the object?
* Create new storage helpers in `MediaRepositoryStore`:
  * [x] Set media restrictions
  * [x] Get media restrictions

For: famedly/product-management#3350