### PR TITLE
MSC3911 AP4: Update methods for profile updates to support attaching media

### DIFF
--- a/synapse/handlers/profile.py
+++ b/synapse/handlers/profile.py
@@ -332,8 +332,6 @@ class ProfileHandler:
                 target_user, authenticated_entity=requester.authenticated_entity
             )
 
-        await self.store.set_profile_avatar_url(target_user, avatar_url_to_set)
-
         # msc3911: Update the media restrictions to include the profile user ID
         if self.enable_restricted_media and avatar_url_to_set:
             await self.hs.get_datastores().main.set_media_restricted_to_user_profile(
@@ -341,6 +339,8 @@ class ProfileHandler:
                 avatar_url_to_set,
                 str(target_user),
             )
+
+        await self.store.set_profile_avatar_url(target_user, avatar_url_to_set)
 
         profile = await self.store.get_profileinfo(target_user)
         await self.user_directory_handler.handle_local_profile_change(

--- a/synapse/handlers/profile.py
+++ b/synapse/handlers/profile.py
@@ -20,7 +20,10 @@
 #
 import logging
 import random
+from http import HTTPStatus
 from typing import TYPE_CHECKING, List, Optional, Union
+
+from matrix_common.types.mxc_uri import MXCUri
 
 from synapse.api.constants import ProfileFields
 from synapse.api.errors import (
@@ -78,6 +81,9 @@ class ProfileHandler:
         self._third_party_rules = hs.get_module_api_callbacks().third_party_event_rules
 
         self.enable_restricted_media = hs.config.experimental.msc3911_enabled
+        self.disable_unrestricted_media = (
+            hs.config.experimental.msc3911_unrestricted_media_upload_disabled
+        )
 
     async def get_profile(self, user_id: str, ignore_backoff: bool = True) -> JsonDict:
         """
@@ -275,6 +281,56 @@ class ProfileHandler:
 
             return result.get("avatar_url")
 
+    async def validate_avatar_url(self, avatar_url: str, requester: Requester) -> None:
+        """
+        Validate avatar_url to make sure the media is owned by the requester or media
+        is already attached to other event or profile.
+
+        Args:
+            avatar_url: The raw avatar_url arg of request
+            requester: The user making the request
+
+        Returns:
+            Return None when all the validations pass
+
+        Raises:
+            SynapseError: If any of the media is inappropriate or if the requester was not
+                allowed to attach the media
+        """
+        if not avatar_url.startswith("mxc://"):
+            avatar_url = f"mxc://{avatar_url}"
+        mxc_uri = MXCUri.from_str(avatar_url)
+
+        media_info = await self.hs.get_datastores().main.get_local_media(
+            mxc_uri.media_id
+        )
+        if media_info is None or media_info.user_id != requester.user.to_string():
+            raise SynapseError(
+                HTTPStatus.BAD_REQUEST,
+                f"The media attachment request is invalid as the media '{mxc_uri.media_id}' does not exist",
+                Codes.INVALID_PARAM,
+            )
+        if self.disable_unrestricted_media and not media_info.restricted:
+            raise SynapseError(
+                HTTPStatus.BAD_REQUEST,
+                f"The media attachment request is invalid as the media '{mxc_uri.media_id}' is not restricted",
+                Codes.INVALID_PARAM,
+            )
+        if (
+            media_info.restricted
+            and media_info.attachments
+            and (
+                media_info.attachments.event_id
+                or media_info.attachments.profile_user_id
+            )
+        ):
+            raise SynapseError(
+                HTTPStatus.BAD_REQUEST,
+                f"The media attachment request is invalid as the media '{mxc_uri.media_id}' is already attached",
+                Codes.INVALID_PARAM,
+            )
+        return
+
     async def set_avatar_url(
         self,
         target_user: UserID,
@@ -334,6 +390,7 @@ class ProfileHandler:
 
         # msc3911: Update the media restrictions to include the profile user ID
         if self.enable_restricted_media and avatar_url_to_set:
+            await self.validate_avatar_url(avatar_url_to_set, requester)
             await self.hs.get_datastores().main.set_media_restricted_to_user_profile(
                 self.hs.config.server.server_name,
                 avatar_url_to_set,

--- a/synapse/media/media_repository.py
+++ b/synapse/media/media_repository.py
@@ -23,7 +23,6 @@ import errno
 import logging
 import os
 import shutil
-from http import HTTPStatus
 from io import BytesIO
 from typing import IO, TYPE_CHECKING, Dict, List, Optional, Set, Tuple
 
@@ -533,41 +532,6 @@ class MediaRepository:
             await respond_with_responder(
                 request, responder, media_type, media_length, upload_name
             )
-
-    async def validate_media_url_and_retrieve_media_info(
-        self, media_id: str, requester: Requester
-    ) -> LocalMedia:
-        """
-        Validate media_id arg and parse the mxc_uri. Then retrieve the media information.
-
-        Args:
-            media_id: The raw media_id arg of request
-            requester: The user making the request
-
-        Returns:
-            Return the media info, or None if appropriate
-
-        Raises:
-            SynapseError: If any of the media is inappropriate or if the requester was not
-                allowed to attach the media
-        """
-        if not media_id.startswith("mxc://"):
-            media_id = f"mxc://{media_id}"
-        mxc_uri = MXCUri.from_str(media_id)
-        media_info = await self.store.get_local_media(mxc_uri.media_id)
-        if media_info is None or media_info.user_id != requester.user.to_string():
-            raise SynapseError(
-                HTTPStatus.BAD_REQUEST,
-                f"The media attachment request is invalid as the media '{mxc_uri.media_id}' does not exist",
-                Codes.INVALID_PARAM,
-            )
-        if not media_info.restricted:
-            raise SynapseError(
-                HTTPStatus.BAD_REQUEST,
-                f"The media attachment request is invalid as the media '{mxc_uri.media_id}' is not restricted",
-                Codes.INVALID_PARAM,
-            )
-        return media_info
 
     async def get_remote_media(
         self,

--- a/synapse/rest/client/profile.py
+++ b/synapse/rest/client/profile.py
@@ -38,7 +38,6 @@ from synapse.http.servlet import (
 )
 from synapse.http.site import SynapseRequest
 from synapse.rest.client._base import client_patterns
-from synapse.storage.databases.main.media_repository import LocalMedia
 from synapse.types import JsonDict, JsonValue, Requester, UserID
 from synapse.util.stringutils import is_namedspaced_grammar
 
@@ -113,42 +112,10 @@ class ProfileFieldRestServlet(RestServlet):
         self.profile_handler = hs.get_profile_handler()
         self.auth = hs.get_auth()
         self.enable_restricted_media = hs.config.experimental.msc3911_enabled
+        self.disable_unrestricted_media = (
+            hs.config.experimental.msc3911_unrestricted_media_upload_disabled
+        )
         self.media_repository = hs.get_media_repository()
-
-    async def validate_avatar_url_and_retrieve_media_info(
-        self, avatar_url: str, requester: Requester
-    ) -> LocalMedia:
-        """
-        Validate avatar_url arg and parse the mxc_uri. Then retrieve the media information.
-
-        Args:
-            avatar_url: The raw avatar_url arg of request
-            requester: The user making the request
-
-        Returns:
-            Return the media info, or None if appropriate
-
-        Raises:
-            SynapseError: If any of the media is inappropriate or if the requester was not
-                allowed to attach the media
-        """
-        if not avatar_url.startswith("mxc://"):
-            avatar_url = f"mxc://{avatar_url}"
-        mxc_uri = MXCUri.from_str(avatar_url)
-        media_info = await self.media_repository.store.get_local_media(mxc_uri.media_id)
-        if media_info is None or media_info.user_id != requester.user.to_string():
-            raise SynapseError(
-                HTTPStatus.BAD_REQUEST,
-                f"The media attachment request is invalid as the media '{mxc_uri.media_id}' does not exist",
-                Codes.INVALID_PARAM,
-            )
-        if not media_info.restricted:
-            raise SynapseError(
-                HTTPStatus.BAD_REQUEST,
-                f"The media attachment request is invalid as the media '{mxc_uri.media_id}' is not restricted",
-                Codes.INVALID_PARAM,
-            )
-        return media_info
 
     async def on_GET(
         self, request: SynapseRequest, user_id: str, field_name: str
@@ -187,6 +154,54 @@ class ProfileFieldRestServlet(RestServlet):
             field_value = await self.profile_handler.get_profile_field(user, field_name)
 
         return 200, {field_name: field_value}
+
+    async def validate_avatar_url(self, avatar_url: str, requester: Requester) -> None:
+        """
+        Validate avatar_url to make sure the media is owned by the requester or media
+        is already attached to other event or profile.
+
+        Args:
+            avatar_url: The raw avatar_url arg of request
+            requester: The user making the request
+
+        Returns:
+            Return None when all the validations pass
+
+        Raises:
+            SynapseError: If any of the media is inappropriate or if the requester was not
+                allowed to attach the media
+        """
+        if not avatar_url.startswith("mxc://"):
+            avatar_url = f"mxc://{avatar_url}"
+        mxc_uri = MXCUri.from_str(avatar_url)
+
+        media_info = await self.media_repository.store.get_local_media(mxc_uri.media_id)
+        if media_info is None or media_info.user_id != requester.user.to_string():
+            raise SynapseError(
+                HTTPStatus.BAD_REQUEST,
+                f"The media attachment request is invalid as the media '{mxc_uri.media_id}' does not exist",
+                Codes.INVALID_PARAM,
+            )
+        if self.disable_unrestricted_media and not media_info.restricted:
+            raise SynapseError(
+                HTTPStatus.BAD_REQUEST,
+                f"The media attachment request is invalid as the media '{mxc_uri.media_id}' is not restricted",
+                Codes.INVALID_PARAM,
+            )
+        if (
+            media_info.restricted
+            and media_info.attachments
+            and (
+                media_info.attachments.event_id
+                or media_info.attachments.profile_user_id
+            )
+        ):
+            raise SynapseError(
+                HTTPStatus.BAD_REQUEST,
+                f"The media attachment request is invalid as the media '{mxc_uri.media_id}' is already attached",
+                Codes.INVALID_PARAM,
+            )
+        return
 
     async def on_PUT(
         self, request: SynapseRequest, user_id: str, field_name: str
@@ -248,16 +263,10 @@ class ProfileFieldRestServlet(RestServlet):
                         requester.user
                     )
                 )
-                if current_avatar_url and new_value == str(
-                    MXCUri(self.hs.hostname, current_avatar_url)
-                ):
+                # If new_value is the same as existing one, keep the function idempotent
+                if current_avatar_url and str(current_avatar_url) == new_value:
                     return 200, {}
-                validated_media = (
-                    await self.validate_avatar_url_and_retrieve_media_info(
-                        new_value, requester
-                    )
-                )
-                new_value = validated_media.media_id
+                await self.validate_avatar_url(new_value, requester)
             await self.profile_handler.set_avatar_url(
                 user, requester, new_value, is_admin, propagate=propagate
             )

--- a/synapse/rest/client/profile.py
+++ b/synapse/rest/client/profile.py
@@ -25,8 +25,6 @@ import re
 from http import HTTPStatus
 from typing import TYPE_CHECKING, Tuple
 
-from matrix_common.types.mxc_uri import MXCUri
-
 from synapse.api.constants import ProfileFields
 from synapse.api.errors import Codes, SynapseError
 from synapse.handlers.profile import MAX_CUSTOM_FIELD_LEN
@@ -38,8 +36,7 @@ from synapse.http.servlet import (
 )
 from synapse.http.site import SynapseRequest
 from synapse.rest.client._base import client_patterns
-from synapse.storage.databases.main.media_repository import LocalMedia
-from synapse.types import JsonDict, JsonValue, Requester, UserID
+from synapse.types import JsonDict, JsonValue, UserID
 from synapse.util.stringutils import is_namedspaced_grammar
 
 if TYPE_CHECKING:
@@ -114,45 +111,6 @@ class ProfileFieldRestServlet(RestServlet):
         self.auth = hs.get_auth()
         self.enable_restricted_media = hs.config.experimental.msc3911_enabled
         self.media_repository = hs.get_media_repository()
-
-    async def _validate_avatar_url_and_retrieve_media_info(
-        self, avatar_url: str, requester: Requester
-    ) -> LocalMedia:
-        """
-        Validate avatar_url arg and parse the mxc_uri. Then retrieve the media information.
-
-        Args:
-            avatar_url: The raw avatar_url arg of request
-            requester: The user making the request
-
-        Returns:
-            Return the media info, or None if appropriate
-
-        Raises:
-            SynapseError: If any of the media is inappropriate or if the requester was not
-                allowed to attach the media
-        """
-        mxc_uri = MXCUri.from_str(avatar_url)
-        media_info = await self.media_repository.store.get_local_media(mxc_uri.media_id)
-        if media_info is None:
-            raise SynapseError(
-                HTTPStatus.BAD_REQUEST,
-                f"The media attachment request is invalid as the media '{mxc_uri.media_id}' does not exist",
-                Codes.INVALID_PARAM,
-            )
-        if not media_info.restricted:
-            raise SynapseError(
-                HTTPStatus.BAD_REQUEST,
-                f"The media attachment request is invalid as the media '{mxc_uri.media_id}' is not restricted",
-                Codes.INVALID_PARAM,
-            )
-        if media_info.user_id != requester.user.to_string():
-            raise SynapseError(
-                HTTPStatus.BAD_REQUEST,
-                f"The media attachment request is invalid as the media '{mxc_uri.media_id}' does not exist",
-                Codes.INVALID_PARAM,
-            )
-        return media_info
 
     async def on_GET(
         self, request: SynapseRequest, user_id: str, field_name: str
@@ -247,16 +205,13 @@ class ProfileFieldRestServlet(RestServlet):
                 user, requester, new_value, is_admin, propagate=propagate
             )
         elif field_name == ProfileFields.AVATAR_URL:
-            media = new_value
             if self.enable_restricted_media and new_value:
-                validated_media = (
-                    await self._validate_avatar_url_and_retrieve_media_info(
-                        new_value, requester
-                    )
+                validated_media = await self.media_repository.validate_media_url_and_retrieve_media_info(
+                    new_value, requester
                 )
-                media = validated_media.media_id
+                new_value = validated_media.media_id
             await self.profile_handler.set_avatar_url(
-                user, requester, media, is_admin, propagate=propagate
+                user, requester, new_value, is_admin, propagate=propagate
             )
         else:
             await self.profile_handler.set_profile_field(

--- a/synapse/rest/client/profile.py
+++ b/synapse/rest/client/profile.py
@@ -25,6 +25,8 @@ import re
 from http import HTTPStatus
 from typing import TYPE_CHECKING, Tuple
 
+from matrix_common.types.mxc_uri import MXCUri
+
 from synapse.api.constants import ProfileFields
 from synapse.api.errors import Codes, SynapseError
 from synapse.handlers.profile import MAX_CUSTOM_FIELD_LEN
@@ -36,7 +38,8 @@ from synapse.http.servlet import (
 )
 from synapse.http.site import SynapseRequest
 from synapse.rest.client._base import client_patterns
-from synapse.types import JsonDict, JsonValue, UserID
+from synapse.storage.databases.main.media_repository import LocalMedia
+from synapse.types import JsonDict, JsonValue, Requester, UserID
 from synapse.util.stringutils import is_namedspaced_grammar
 
 if TYPE_CHECKING:
@@ -109,6 +112,47 @@ class ProfileFieldRestServlet(RestServlet):
         self.hs = hs
         self.profile_handler = hs.get_profile_handler()
         self.auth = hs.get_auth()
+        self.enable_restricted_media = hs.config.experimental.msc3911_enabled
+        self.media_repository = hs.get_media_repository()
+
+    async def _validate_avatar_url_and_retrieve_media_info(
+        self, avatar_url: str, requester: Requester
+    ) -> LocalMedia:
+        """
+        Validate avatar_url arg and parse the mxc_uri. Then retrieve the media information.
+
+        Args:
+            avatar_url: The raw avatar_url arg of request
+            requester: The user making the request
+
+        Returns:
+            Return the media info, or None if appropriate
+
+        Raises:
+            SynapseError: If any of the media is inappropriate or if the requester was not
+                allowed to attach the media
+        """
+        mxc_uri = MXCUri.from_str(avatar_url)
+        media_info = await self.media_repository.store.get_local_media(mxc_uri.media_id)
+        if media_info is None:
+            raise SynapseError(
+                HTTPStatus.BAD_REQUEST,
+                f"The media attachment request is invalid as the media '{mxc_uri.media_id}' does not exist",
+                Codes.INVALID_PARAM,
+            )
+        if not media_info.restricted:
+            raise SynapseError(
+                HTTPStatus.BAD_REQUEST,
+                f"The media attachment request is invalid as the media '{mxc_uri.media_id}' is not restricted",
+                Codes.INVALID_PARAM,
+            )
+        if media_info.user_id != requester.user.to_string():
+            raise SynapseError(
+                HTTPStatus.BAD_REQUEST,
+                f"The media attachment request is invalid as the media '{mxc_uri.media_id}' does not exist",
+                Codes.INVALID_PARAM,
+            )
+        return media_info
 
     async def on_GET(
         self, request: SynapseRequest, user_id: str, field_name: str
@@ -203,8 +247,16 @@ class ProfileFieldRestServlet(RestServlet):
                 user, requester, new_value, is_admin, propagate=propagate
             )
         elif field_name == ProfileFields.AVATAR_URL:
+            media = new_value
+            if self.enable_restricted_media and new_value:
+                validated_media = (
+                    await self._validate_avatar_url_and_retrieve_media_info(
+                        new_value, requester
+                    )
+                )
+                media = validated_media.media_id
             await self.profile_handler.set_avatar_url(
-                user, requester, new_value, is_admin, propagate=propagate
+                user, requester, media, is_admin, propagate=propagate
             )
         else:
             await self.profile_handler.set_profile_field(

--- a/synapse/storage/databases/main/media_repository.py
+++ b/synapse/storage/databases/main/media_repository.py
@@ -1227,13 +1227,16 @@ class MediaRepositoryStore(MediaRepositoryBackgroundUpdateStore):
         Add the media restrictions to a given profile for a User ID to the database
 
         Args:
-           server_name:
-           media_id:
+           server_name: The name of the server
+           media_id: The media ID that doesn't contain "mxc://{servername}/"
            profile_user_id: The User ID's profile to restrict the media to
 
         Raises:
             SynapseError if the media already has restrictions on it
         """
+        if "mxc://" in media_id:
+            # parse mxc_uri into media_id
+            media_id = media_id.split("/")[-1]
         await self.db_pool.runInteraction(
             "set_media_restricted_to_user_profile",
             self.set_media_restricted_to_user_profile_txn,

--- a/tests/rest/client/test_profile.py
+++ b/tests/rest/client/test_profile.py
@@ -1102,7 +1102,7 @@ class ProfileMediaAttachmentTestCase(unittest.HomeserverTestCase):
             )
         )
         assert user_avatar is not None
-        assert user_avatar in str(mxc_uri)
+        assert "mxc://test/" + user_avatar == str(mxc_uri)
 
         # Remove the media from the user profile.
         channel = self.make_request(


### PR DESCRIPTION
# Linked Media MSC3911 AP4: Update methods for profile updates to support attaching media [#3354](https://github.com/famedly/product-management/issues/3354)

For linking media we not only have events, but also profiles, that can be queried over federation independently of events. These should also allow attaching media.

## Acceptance criteria

- [x] ~~https://spec.matrix.org/v1.4/client-server-api/#put_matrixclientv3profileuseridavatar_url should take a parameter of `org.matrix.msc3911.attach_media` to allow attaching media to a profile~~
- [x] https://spec.matrix.org/v1.4/client-server-api/#put_matrixclientv3profileuseridavatar_url should use existing request body param `avatar_url`, check if it's restricted and attach proper restrictions
- [x] This should set the appropriate restrictions in the DB
- [x] Already attached media should return an error.

## Open Questions
(from the ticket) We need to ensure synapse returns the right avatar over federation, otherwise this restriction is impossible to apply. That might require some digging?