### PR TITLE
MSC3911: Follow up to AP3 - Atomic persistence of media restrictions with events

### DIFF
--- a/synapse/handlers/message.py
+++ b/synapse/handlers/message.py
@@ -2133,18 +2133,6 @@ class EventCreationHandler:
 
         events_and_pos = []
         for event in persisted_events:
-            # Access the 'media_references' object from the event internal metadata.
-            # This will be None if it was not attached during creation of the event.
-            maybe_media_restrictions_to_set = event.internal_metadata.media_references
-
-            if maybe_media_restrictions_to_set:
-                for mxc_str in maybe_media_restrictions_to_set:
-                    mxc = MXCUri.from_str(mxc_str)
-                    await self.store.set_media_restrictions(
-                        mxc.server_name,
-                        mxc.media_id,
-                        {"restrictions": {"event_id": event.event_id}},
-                    )
             if self._ephemeral_events_enabled:
                 # If there's an expiry timestamp on the event, schedule its expiry.
                 self._message_handler.maybe_schedule_expiry(event)

--- a/tests/rest/client/test_rooms.py
+++ b/tests/rest/client/test_rooms.py
@@ -4615,10 +4615,10 @@ class RoomStateMediaAttachmentTestCase(unittest.HomeserverTestCase):
         mxc_uri = self.create_media_and_set_restricted_flag()
         # attach media to some other event before we place our state request
         self.get_success(
-            self.store.set_media_restrictions(
+            self.store.set_media_restricted_to_event_id(
                 mxc_uri.server_name,
                 mxc_uri.media_id,
-                {"restrictions": {"event_id": "$some_fake_event_id"}},
+                "$some_fake_event_id",
             )
         )
 
@@ -4920,10 +4920,10 @@ class RoomSendEventMediaAttachmentTestCase(unittest.HomeserverTestCase):
 
         # attach media to some other event before we place our send event request
         self.get_success(
-            self.store.set_media_restrictions(
+            self.store.set_media_restricted_to_event_id(
                 mxc_uri.server_name,
                 mxc_uri.media_id,
-                {"restrictions": {"event_id": "$some_fake_event_id"}},
+                "$some_fake_event_id",
             )
         )
 

--- a/tests/storage/test_media.py
+++ b/tests/storage/test_media.py
@@ -30,11 +30,10 @@ class MediaAttachmentStorageTestCase(unittest.HomeserverTestCase):
 
     def test_store_and_retrieve_media_restrictions_by_event_id(self) -> None:
         event_id = "$random_event_id"
-        media_restrictions = {"restrictions": {"event_id": event_id}}
         media_id = random_string(24)
         self.get_success_or_raise(
-            self.store.set_media_restrictions(
-                self.server_name, media_id, media_restrictions
+            self.store.set_media_restricted_to_event_id(
+                self.server_name, media_id, event_id
             )
         )
 
@@ -47,11 +46,10 @@ class MediaAttachmentStorageTestCase(unittest.HomeserverTestCase):
 
     def test_store_and_retrieve_media_restrictions_by_profile_user_id(self) -> None:
         user_id = UserID.from_string("@frank:test")
-        media_restrictions = {"restrictions": {"profile_user_id": user_id.to_string()}}
         media_id = random_string(24)
         self.get_success_or_raise(
-            self.store.set_media_restrictions(
-                self.server_name, media_id, media_restrictions
+            self.store.set_media_restricted_to_user_profile(
+                self.server_name, media_id, user_id.to_string()
             )
         )
 
@@ -109,12 +107,11 @@ class MediaPendingAttachmentTestCase(unittest.HomeserverTestCase):
         content_uri: str = upload_result["content_uri"]
         # We can split the content_uri on the last "/" and the rest is the media_id
         media_id = content_uri.rsplit("/", maxsplit=1)[1]
-
         event_id = "$something_hashy_doesnt_matter"
-        media_restrictions = {"restrictions": {"event_id": event_id}}
+
         self.get_success(
-            self.store.set_media_restrictions(
-                self.server_name, media_id, media_restrictions
+            self.store.set_media_restricted_to_event_id(
+                self.server_name, media_id, event_id
             )
         )
 
@@ -127,8 +124,8 @@ class MediaPendingAttachmentTestCase(unittest.HomeserverTestCase):
         assert existing_media_restrictions is not None
 
         self.get_failure(
-            self.store.set_media_restrictions(
-                self.server_name, media_id, media_restrictions
+            self.store.set_media_restricted_to_event_id(
+                self.server_name, media_id, event_id
             ),
             SynapseError,
         )
@@ -176,7 +173,8 @@ class MediaAttachmentFlowTestCase(unittest.HomeserverTestCase):
         # Create media by using create_or_update_content() helper. This will likely be
         # on the new `/create` and `/upload` endpoints for msc3911.
 
-        # set actual restrictions using storage method `set_media_restrictions()`
+        # set actual restrictions using storage methods
+        # `set_media_restricted_to_event_id()` or `set_media_restricted_to_user_profile()`
 
         # use `get_local_media()` to retrieve the data
 
@@ -193,10 +191,10 @@ class MediaAttachmentFlowTestCase(unittest.HomeserverTestCase):
 
         event_id = "$event_id_hash_goes_here"
         self.get_success(
-            self.store.set_media_restrictions(
+            self.store.set_media_restricted_to_event_id(
                 self.server_name,
                 media_id,
-                {"restrictions": {"event_id": event_id}},
+                event_id,
             )
         )
 


### PR DESCRIPTION
Follow up to AP3, where failure to set media restrictions would still allow an event to exist. This makes the process be atomic. Failure of one leads to failure of the other