### PR TITLE
AP4 fix: remove unused repository

### DIFF
--- a/synapse/rest/client/profile.py
+++ b/synapse/rest/client/profile.py
@@ -110,7 +110,6 @@ class ProfileFieldRestServlet(RestServlet):
         self.profile_handler = hs.get_profile_handler()
         self.auth = hs.get_auth()
         self.enable_restricted_media = hs.config.experimental.msc3911_enabled
-        self.media_repository = hs.get_media_repository()
 
     async def on_GET(
         self, request: SynapseRequest, user_id: str, field_name: str


### PR DESCRIPTION
There's error regarding media_repository
```
{"log":"Error during startup","namespace":"synapse.app._base","level":"CRITICAL","time":1756983544.76,"request":"sentinel","server_name":"internal-test-tim-pro-beta.dev.scw.famedly.net","exc_type":"AttributeError","exc_value":"'ContentRepositoryConfig' object has no attribute 'max_upload_size'"}
Error during startup:
Traceback (most recent call last):
  File "/usr/local/lib/python3.12/site-packages/synapse/app/_base.py", line 259, in wrapper
    await cb(*args, **kwargs)
  File "/usr/local/lib/python3.12/site-packages/synapse/app/homeserver.py", line 386, in start
    await _base.start(hs)
  File "/usr/local/lib/python3.12/site-packages/synapse/app/_base.py", line 587, in start
    hs.start_listening()
  File "/usr/local/lib/python3.12/site-packages/synapse/app/homeserver.py", line 275, in start_listening
    self._listener_http(self.config, listener)
  File "/usr/local/lib/python3.12/site-packages/synapse/app/homeserver.py", line 113, in _listener_http
    resources.update(self._configure_named_resource(name, res.compress))
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/synapse/app/homeserver.py", line 179, in _configure_named_resource
    client_resource: Resource = ClientRestResource(self)
                                ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/synapse/rest/__init__.py", line 149, in __init__
    self.register_servlets(self, hs, servlet_groups)
  File "/usr/local/lib/python3.12/site-packages/synapse/rest/__init__.py", line 193, in register_servlets
    servletfunc(hs, client_resource)
  File "/usr/local/lib/python3.12/site-packages/synapse/rest/client/profile.py", line 292, in register_servlets
    ProfileFieldRestServlet(hs).register(http_server)
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/synapse/rest/client/profile.py", line 113, in __init__
    self.media_repository = hs.get_media_repository()
                            ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/synapse/server.py", line 228, in _get
    dep = builder(self)
          ^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/synapse/server.py", line 704, in get_media_repository
    return MediaRepository(self)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/synapse/media/media_repository.py", line 97, in __init__
    self.max_upload_size = hs.config.media.max_upload_size
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'ContentRepositoryConfig' object has no attribute 'max_upload_size'
```