### PR TITLE
MSC3911 AP8: Expose restrictions over federation

### DIFF
--- a/synapse/federation/transport/server/federation.py
+++ b/synapse/federation/transport/server/federation.py
@@ -78,6 +78,7 @@ class BaseFederationServerServlet(BaseFederationServlet):
     ):
         super().__init__(hs, authenticator, ratelimiter, server_name)
         self.handler = hs.get_federation_server()
+        self.enable_restricted_media = hs.config.experimental.msc3911_enabled
 
 
 class FederationSendServlet(BaseFederationServerServlet):

--- a/synapse/media/_base.py
+++ b/synapse/media/_base.py
@@ -309,6 +309,7 @@ async def respond_with_multipart_responder(
     media_type: str,
     media_length: Optional[int],
     upload_name: Optional[str],
+    json_response: Optional[dict] = None,
 ) -> None:
     """
     Responds to requests originating from the federation media `/download` endpoint by
@@ -362,7 +363,9 @@ async def respond_with_multipart_responder(
             clock,
             request,
             media_type,
-            {},  # Note: if we change this we need to change the returned ETag.
+            json_response
+            if json_response
+            else {},  # Note: if we change this we need to change the returned ETag.
             disposition,
             media_length,
         )

--- a/synapse/storage/databases/main/media_repository.py
+++ b/synapse/storage/databases/main/media_repository.py
@@ -74,6 +74,13 @@ class MediaRestrictions:
     event_id: Optional[str] = None
     profile_user_id: Optional[UserID] = None
 
+    def to_dict(self) -> dict:
+        if self.event_id:
+            return {"restrictions": {"event_id": str(self.event_id)}}
+        if self.profile_user_id:
+            return {"restrictions": {"profile_user_id": str(self.profile_user_id)}}
+        return {}
+
 
 @attr.s(slots=True, frozen=True, auto_attribs=True)
 class LocalMedia:

--- a/synapse/storage/databases/main/media_repository.py
+++ b/synapse/storage/databases/main/media_repository.py
@@ -76,9 +76,13 @@ class MediaRestrictions:
 
     def to_dict(self) -> dict:
         if self.event_id:
-            return {"restrictions": {"event_id": str(self.event_id)}}
+            return {"org.matrix.msc3911.restrictions": {"event_id": str(self.event_id)}}
         if self.profile_user_id:
-            return {"restrictions": {"profile_user_id": str(self.profile_user_id)}}
+            return {
+                "org.matrix.msc3911.restrictions": {
+                    "profile_user_id": str(self.profile_user_id)
+                }
+            }
         return {}
 
 

--- a/tests/federation/test_federation_media.py
+++ b/tests/federation/test_federation_media.py
@@ -271,7 +271,10 @@ class FederationRestrictedMediaDownloadsTest(unittest.FederatingHomeserverTestCa
                 break
 
         assert json_obj is not None, "No JSON part found"
-        assert json_obj.get("restrictions", {}).get("event_id") == "random-event-id"
+        assert (
+            json_obj.get("org.matrix.msc3911.restrictions", {}).get("event_id")
+            == "random-event-id"
+        )
 
         # Check the png file exists and matches what was uploaded
         found_file = any(SMALL_PNG in field for field in stripped_bytes)
@@ -532,7 +535,7 @@ class FederationRestrictedThumbnailTest(unittest.FederatingHomeserverTestCase):
 
         assert json_obj is not None, "No JSON part found"
         assert (
-            json_obj.get("restrictions", {}).get("profile_user_id")
+            json_obj.get("org.matrix.msc3911.restrictions", {}).get("profile_user_id")
             == "@user_id:whatever.org"
         )
 

--- a/tests/federation/test_federation_media.py
+++ b/tests/federation/test_federation_media.py
@@ -18,6 +18,7 @@
 #
 #
 import io
+import json
 import os
 import shutil
 import tempfile
@@ -30,9 +31,11 @@ from synapse.media.storage_provider import (
     FileStorageProviderBackend,
     StorageProviderWrapper,
 )
+from synapse.rest.client import login
 from synapse.server import HomeServer
-from synapse.types import UserID
-from synapse.util import Clock
+from synapse.storage.database import LoggingTransaction
+from synapse.types import JsonDict, UserID
+from synapse.util import Clock, json_encoder
 
 from tests import unittest
 from tests.media.test_media_storage import small_png
@@ -187,6 +190,161 @@ class FederationMediaDownloadsTest(unittest.FederatingHomeserverTestCase):
         self.assertNotIn("body", channel.result)
 
 
+class FederationRestrictedMediaDownloadsTest(unittest.FederatingHomeserverTestCase):
+    servlets = [
+        login.register_servlets,
+    ]
+
+    def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
+        super().prepare(reactor, clock, hs)
+        self.test_dir = tempfile.mkdtemp(prefix="synapse-tests-")
+        self.addCleanup(shutil.rmtree, self.test_dir)
+        self.primary_base_path = os.path.join(self.test_dir, "primary")
+        self.secondary_base_path = os.path.join(self.test_dir, "secondary")
+        hs.config.media.media_store_path = self.primary_base_path
+        self.store = hs.get_datastores().main
+
+        storage_providers = [
+            StorageProviderWrapper(
+                FileStorageProviderBackend(hs, self.secondary_base_path),
+                store_local=True,
+                store_remote=False,
+                store_synchronous=True,
+            )
+        ]
+
+        self.filepaths = MediaFilePaths(self.primary_base_path)
+        self.media_storage = MediaStorage(
+            hs, self.primary_base_path, self.filepaths, storage_providers
+        )
+        self.media_repo = hs.get_media_repository()
+
+    def default_config(self) -> JsonDict:
+        config = super().default_config()
+        config.setdefault("experimental_features", {})
+        config["experimental_features"].update({"msc3911_enabled": True})
+        return config
+
+    def test_restricted_media_download_with_restrictions_field(self) -> None:
+        content = io.BytesIO(SMALL_PNG)
+        content_uri = self.get_success(
+            self.media_repo.create_or_update_content(
+                "image/png",
+                "test_png_upload",
+                content,
+                67,
+                UserID.from_string("@user_id:something.org"),
+                restricted=True,
+            )
+        )
+        # Attach restrictions to the media
+        self.get_success(
+            self.media_repo.store.set_media_restricted_to_event_id(
+                self.hs.hostname, content_uri.media_id, "random-event-id"
+            )
+        )
+        # Send download request with federation endpoint
+        channel = self.make_signed_federation_request(
+            "GET",
+            f"/_matrix/federation/v1/media/download/{content_uri.media_id}",
+        )
+        self.assertEqual(200, channel.code)
+
+        content_type = channel.headers.getRawHeaders("content-type")
+        assert content_type is not None
+        assert "multipart/mixed" in content_type[0]
+        assert "boundary" in content_type[0]
+
+        boundary = content_type[0].split("boundary=")[1]
+        body = channel.result.get("body")
+        assert body is not None
+
+        # Assert a JSON part exists with field restrictions
+        stripped_bytes = body.split(b"\r\n" + b"--" + boundary.encode("utf-8"))
+        json_obj = None
+        for part in stripped_bytes:
+            if b"Content-Type: application/json" in part:
+                idx = part.find(b"\r\n\r\n")
+                assert idx != -1, "No JSON payload found after header"
+                json_bytes = part[idx + 4 :].strip()
+                json_obj = json.loads(json_bytes.decode("utf-8"))
+                break
+
+        assert json_obj is not None, "No JSON part found"
+        assert json_obj.get("restrictions", {}).get("event_id") == "random-event-id"
+
+        # Check the png file exists and matches what was uploaded
+        found_file = any(SMALL_PNG in field for field in stripped_bytes)
+        self.assertTrue(found_file)
+
+    def test_restricted_media_download_without_restrictions_field_fails(self) -> None:
+        content = io.BytesIO(SMALL_PNG)
+        content_uri = self.get_success(
+            self.media_repo.create_or_update_content(
+                "image/png",
+                "test_png_upload",
+                content,
+                67,
+                UserID.from_string("@user_id:whatever.org"),
+                restricted=True,
+            )
+        )
+
+        # Send download request with federation endpoint
+        channel = self.make_signed_federation_request(
+            "GET",
+            f"/_matrix/federation/v1/media/download/{content_uri.media_id}",
+        )
+        self.assertEqual(404, channel.code)
+        self.assertIn(b"Not found", channel.result.get("body", b""))
+
+    def test_restricted_media_download_with_invalid_restrictions_field_fails(
+        self,
+    ) -> None:
+        content = io.BytesIO(SMALL_PNG)
+        content_uri = self.get_success(
+            self.media_repo.create_or_update_content(
+                "image/png",
+                "test_png_upload",
+                content,
+                67,
+                UserID.from_string("@user_id:whatever.org"),
+                restricted=True,
+            )
+        )
+        # Append invalid restrictions set for test
+        json_object = {"random_field": "random_value"}
+
+        def insert_restriction(txn: LoggingTransaction) -> None:
+            self.store.db_pool.simple_insert_txn(
+                txn,
+                table="media_attachments",
+                values={
+                    "server_name": self.hs.hostname,
+                    "media_id": content_uri.media_id,
+                    "restrictions_json": json_encoder.encode(json_object),
+                },
+            )
+
+        self.get_success(
+            self.store.db_pool.runInteraction(
+                "test_restricted_media_download_with_invalid_restrictions_field_fails",
+                insert_restriction,
+            )
+        )
+
+        # Send download request with federation endpoint
+        channel = self.make_signed_federation_request(
+            "GET",
+            f"/_matrix/federation/v1/media/download/{content_uri.media_id}",
+        )
+        self.assertEqual(403, channel.code)
+        self.assertIn(
+            b"MediaRestrictions must have exactly one of",
+            channel.result.get("body", b""),
+        )
+
+
 class FederationThumbnailTest(unittest.FederatingHomeserverTestCase):
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         super().prepare(reactor, clock, hs)
@@ -292,4 +450,92 @@ class FederationThumbnailTest(unittest.FederatingHomeserverTestCase):
         found_file = any(
             small_png.expected_cropped in field for field in stripped_bytes
         )
+        self.assertTrue(found_file)
+
+
+class FederationRestrictedThumbnailTest(unittest.FederatingHomeserverTestCase):
+    def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
+        super().prepare(reactor, clock, hs)
+        self.test_dir = tempfile.mkdtemp(prefix="synapse-tests-")
+        self.addCleanup(shutil.rmtree, self.test_dir)
+        self.primary_base_path = os.path.join(self.test_dir, "primary")
+        self.secondary_base_path = os.path.join(self.test_dir, "secondary")
+
+        hs.config.media.media_store_path = self.primary_base_path
+
+        storage_providers = [
+            StorageProviderWrapper(
+                FileStorageProviderBackend(hs, self.secondary_base_path),
+                store_local=True,
+                store_remote=False,
+                store_synchronous=True,
+            )
+        ]
+
+        self.filepaths = MediaFilePaths(self.primary_base_path)
+        self.media_storage = MediaStorage(
+            hs, self.primary_base_path, self.filepaths, storage_providers
+        )
+        self.media_repo = hs.get_media_repository()
+
+    def default_config(self) -> JsonDict:
+        config = super().default_config()
+        config.setdefault("experimental_features", {})
+        config["experimental_features"].update({"msc3911_enabled": True})
+        return config
+
+    def test_restricted_thumbnail_download_with_restrictions_field(self) -> None:
+        content = io.BytesIO(small_png.data)
+        content_uri = self.get_success(
+            self.media_repo.create_or_update_content(
+                "image/png",
+                "test_png_thumbnail",
+                content,
+                67,
+                UserID.from_string("@user_id:whatever.org"),
+                restricted=True,
+            )
+        )
+        # Attach restrictions to the media
+        self.get_success(
+            self.media_repo.store.set_media_restricted_to_user_profile(
+                self.hs.hostname, content_uri.media_id, "@user_id:whatever.org"
+            )
+        )
+
+        # Send download request with federation endpoint
+        channel = self.make_signed_federation_request(
+            "GET",
+            f"/_matrix/federation/v1/media/thumbnail/{content_uri.media_id}?width=32&height=32&method=scale",
+        )
+        self.assertEqual(200, channel.code)
+
+        content_type = channel.headers.getRawHeaders("content-type")
+        assert content_type is not None
+        assert "multipart/mixed" in content_type[0]
+        assert "boundary" in content_type[0]
+
+        boundary = content_type[0].split("boundary=")[1]
+        body = channel.result.get("body")
+        assert body is not None
+
+        # Assert a JSON part exists with field restrictions
+        stripped_bytes = body.split(b"\r\n" + b"--" + boundary.encode("utf-8"))
+        json_obj = None
+        for part in stripped_bytes:
+            if b"Content-Type: application/json" in part:
+                idx = part.find(b"\r\n\r\n")
+                assert idx != -1, "No JSON payload found after header"
+                json_bytes = part[idx + 4 :].strip()
+                json_obj = json.loads(json_bytes.decode("utf-8"))
+                break
+
+        assert json_obj is not None, "No JSON part found"
+        assert (
+            json_obj.get("restrictions", {}).get("profile_user_id")
+            == "@user_id:whatever.org"
+        )
+
+        # Check that the png file exists and matches the expected scaled bytes
+        found_file = any(small_png.expected_scaled in field for field in stripped_bytes)
         self.assertTrue(found_file)


### PR DESCRIPTION
# Linked Media MSC3911 AP8: Expose restrictions over federation [#3358](https://github.com/famedly/product-management/issues/3358)

fixes [#3358](https://github.com/famedly/product-management/issues/3358)

If restrictions are present, they should be exposed in the first part of the https://spec.matrix.org/v1.14/server-server-api/#get_matrixfederationv1mediadownloadmediaid response.

# Acceptance criteria

- [x] Expose the restrictions json key in https://spec.matrix.org/v1.14/server-server-api/#get_matrixfederationv1mediadownloadmediaid
- [x] This should only be returned, if the msc is enabled.
- [x] The key is prefixed: `org.matrix.msc3911.restrictions` (event_id and profile_user_id are not prefixed) 
- [ ] If the server has no way to be able to see the media, an error should be returned instead of the media. (this is quite tricky, see https://github.com/famedly/product-management/issues/3357 )

- [x] The `/_matrix/federation/v1/media/download` and `/_matrix/federation/v1/media/thumbnail` endpoints specified by https://github.com/matrix-org/matrix-spec-proposals/pull/3916 are extended: the returned json object may have a property restrictions.
- [x] If there is no restrictions property, the media is a legacy "unrestricted" media. Otherwise, restrictions should be a JSON object with one of the following properties: event_id, profile_user_id.
- [x] It is invalid for both event_id and profile_user_id to be set.
- [x] If neither event_id nor profile_user_id are present, the requesting user should assume that an unknown restriction is present, and not allow access to any user.

# Open Questions
Which permission checks over federation are actually feasible, if the server wants to join the room for example?
