### PR TITLE
MSC3911 AP7: Permission checks for download and thumbnail endpoints

### DIFF
--- a/synapse/api/errors.py
+++ b/synapse/api/errors.py
@@ -245,6 +245,13 @@ class InvalidAPICallError(SynapseError):
         super().__init__(HTTPStatus.BAD_REQUEST, msg, Codes.BAD_JSON)
 
 
+class UnauthorizedRequestAPICallError(SynapseError):
+    """Error raised when a request was not allowed due to authorization"""
+
+    def __init__(self, msg: str):
+        super().__init__(HTTPStatus.FORBIDDEN, msg, Codes.UNAUTHORIZED)
+
+
 class InvalidProxyCredentialsError(SynapseError):
     """Error raised when the proxy credentials are invalid."""
 

--- a/synapse/rest/client/media.py
+++ b/synapse/rest/client/media.py
@@ -159,7 +159,7 @@ class ThumbnailResource(RestServlet):
     ) -> None:
         # Validate the server name, raising if invalid
         parse_and_validate_server_name(server_name)
-        await self.auth.get_user_by_req(request, allow_guest=True)
+        requester = await self.auth.get_user_by_req(request, allow_guest=True)
 
         set_cors_headers(request)
         set_corp_headers(request)
@@ -184,6 +184,7 @@ class ThumbnailResource(RestServlet):
                     m_type,
                     max_timeout_ms,
                     False,
+                    requester,
                 )
             else:
                 await self.thumbnailer.respond_local_thumbnail(
@@ -195,6 +196,7 @@ class ThumbnailResource(RestServlet):
                     m_type,
                     max_timeout_ms,
                     False,
+                    requester,
                 )
             self.media_repo.mark_recently_accessed(None, media_id)
         else:
@@ -223,6 +225,7 @@ class ThumbnailResource(RestServlet):
                 max_timeout_ms,
                 ip_address,
                 True,
+                requester,
             )
             self.media_repo.mark_recently_accessed(server_name, media_id)
 
@@ -250,7 +253,7 @@ class DownloadResource(RestServlet):
         # Validate the server name, raising if invalid
         parse_and_validate_server_name(server_name)
 
-        await self.auth.get_user_by_req(request, allow_guest=True)
+        requester = await self.auth.get_user_by_req(request, allow_guest=True)
 
         set_cors_headers(request)
         set_corp_headers(request)
@@ -274,7 +277,7 @@ class DownloadResource(RestServlet):
 
         if self._is_mine_server_name(server_name):
             await self.media_repo.get_local_media(
-                request, media_id, file_name, max_timeout_ms
+                request, media_id, file_name, max_timeout_ms, requester
             )
         else:
             ip_address = request.getClientAddress().host
@@ -286,6 +289,7 @@ class DownloadResource(RestServlet):
                 max_timeout_ms,
                 ip_address,
                 True,
+                requester,
             )
 
 

--- a/tests/rest/client/test_media_download.py
+++ b/tests/rest/client/test_media_download.py
@@ -1,0 +1,346 @@
+#
+# This file is licensed under the Affero General Public License (AGPL) version 3.
+#
+# Copyright 2025 The Matrix.org Foundation C.I.C.
+# Copyright (C) 2025 Famedly
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# See the GNU Affero General Public License for more details:
+# <https://www.gnu.org/licenses/agpl-3.0.html>.
+#
+# Originally licensed under the Apache License, Version 2.0:
+# <http://www.apache.org/licenses/LICENSE-2.0>.
+#
+
+import io
+from typing import Optional
+
+from matrix_common.types.mxc_uri import MXCUri
+
+from twisted.test.proto_helpers import MemoryReactor
+from twisted.web.resource import Resource
+
+from synapse.api.constants import (
+    EventContentFields,
+    EventTypes,
+    HistoryVisibility,
+    Membership,
+)
+from synapse.rest import admin
+from synapse.rest.client import login, media, room
+from synapse.server import HomeServer
+from synapse.types import JsonDict, UserID
+from synapse.util import Clock
+
+from tests import unittest
+from tests.test_utils import SMALL_PNG
+from tests.unittest import override_config
+
+
+class RestrictedResourceDownloadTestCase(unittest.HomeserverTestCase):
+    """
+    Test the `/download` media endpoint for restricted media.
+
+    Something to note: rooms here will be set to room history visibility of 'joined'
+    at a minimum, or the media would be visible by default
+    """
+
+    servlets = [
+        media.register_servlets,
+        login.register_servlets,
+        admin.register_servlets,
+        room.register_servlets,
+    ]
+
+    def default_config(self) -> JsonDict:
+        config = super().default_config()
+        config.setdefault("experimental_features", {})
+        config["experimental_features"].update({"msc3911_enabled": True})
+        return config
+
+    def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
+        self.repo = hs.get_media_repository()
+        self.store = hs.get_datastores().main
+        self.creator = self.register_user("creator", "testpass")
+        self.creator_tok = self.login("creator", "testpass")
+        self.other_user = self.register_user("random_user", "testpass")
+        self.other_user_tok = self.login("random_user", "testpass")
+        self.other_profile_test_user = self.register_user(
+            "profile_test_user", "testpass"
+        )
+        self.other_profile_test_user_tok = self.login("profile_test_user", "testpass")
+
+    def create_resource_dict(self) -> dict[str, Resource]:
+        resources = super().create_resource_dict()
+        resources["/_matrix/media"] = self.hs.get_media_repository_resource()
+        return resources
+
+    def _create_restricted_media(self, user: str) -> MXCUri:
+        mxc_uri = self.get_success(
+            self.repo.create_or_update_content(
+                "image/png",
+                "test_png_upload",
+                io.BytesIO(SMALL_PNG),
+                67,
+                UserID.from_string(user),
+                restricted=True,
+            )
+        )
+        return mxc_uri
+
+    def fetch_media(
+        self,
+        mxc_uri: MXCUri,
+        access_token: Optional[str] = None,
+        expected_code: int = 200,
+    ) -> None:
+        """
+        Test retrieving the media. We do not care about the content of the media, just
+        that the response is correct
+        """
+        channel = self.make_request(
+            "GET",
+            f"/_matrix/client/v1/media/download/{mxc_uri.server_name}/{mxc_uri.media_id}",
+            access_token=access_token or self.creator_tok,
+        )
+        assert channel.code == expected_code, channel.code
+
+    def test_user_download_local_media_unrestricted(self) -> None:
+        """Test that unrestricted media is not affected"""
+        mxc_uri = self.get_success(
+            self.repo.create_or_update_content(
+                "image/png",
+                "test_png_upload",
+                io.BytesIO(SMALL_PNG),
+                67,
+                UserID.from_string(self.other_user),
+                restricted=False,
+            )
+        )
+        # The assertion of 200 as a response code is part of the function
+        self.fetch_media(mxc_uri)
+        self.fetch_media(mxc_uri, access_token=self.other_user_tok)
+
+    def test_download_local_media_restricted_but_pending_state(self) -> None:
+        """Test originating user can access media even though it is not attached"""
+        mxc_uri = self._create_restricted_media(self.creator)
+        # The creator user can see their own media
+        self.fetch_media(mxc_uri)
+        # But another user can not
+        self.fetch_media(mxc_uri, access_token=self.other_user_tok, expected_code=403)
+
+    def test_user_download_local_media_attached_to_user_profile_success(self) -> None:
+        """Test retrieving media attached to user's profile"""
+        prime_mxc_uri = self._create_restricted_media(self.creator)
+        other_mxc_uri = self._create_restricted_media(self.other_profile_test_user)
+        # Inject directly to the database, we are not here to test the profile endpoint
+        self.get_success(
+            self.store.set_media_restricted_to_user_profile(
+                prime_mxc_uri.server_name,
+                prime_mxc_uri.media_id,
+                self.creator,
+            )
+        )
+        self.get_success(
+            self.store.set_media_restricted_to_user_profile(
+                other_mxc_uri.server_name,
+                other_mxc_uri.media_id,
+                self.other_profile_test_user,
+            )
+        )
+
+        # Should be able to see their own
+        self.fetch_media(prime_mxc_uri, access_token=self.creator_tok)
+        self.fetch_media(other_mxc_uri, access_token=self.other_profile_test_user_tok)
+
+        # Should be able to see each others
+        self.fetch_media(other_mxc_uri, access_token=self.creator_tok)
+        self.fetch_media(prime_mxc_uri, access_token=self.other_profile_test_user_tok)
+
+    @override_config(
+        {
+            "limit_profile_requests_to_users_who_share_rooms": True,
+        }
+    )
+    def test_user_download_local_media_attached_to_user_profile_failure(self) -> None:
+        """
+        Test that limiting profile requests works as expected. Specifically, that users
+        that are not sharing a room can not see profile avatars
+        """
+
+        prime_mxc_uri = self._create_restricted_media(self.creator)
+        other_mxc_uri = self._create_restricted_media(self.other_profile_test_user)
+        # Inject directly to the database, we are not here to test the profile endpoint
+        self.get_success(
+            self.store.set_media_restricted_to_user_profile(
+                prime_mxc_uri.server_name,
+                prime_mxc_uri.media_id,
+                self.creator,
+            )
+        )
+        self.get_success(
+            self.store.set_media_restricted_to_user_profile(
+                other_mxc_uri.server_name,
+                other_mxc_uri.media_id,
+                self.other_profile_test_user,
+            )
+        )
+
+        # Should be able to see their own
+        self.fetch_media(prime_mxc_uri, access_token=self.creator_tok)
+        self.fetch_media(other_mxc_uri, access_token=self.other_profile_test_user_tok)
+
+        # Should NOT be able to see each others, since the limitation setting is enabled
+        self.fetch_media(
+            other_mxc_uri, access_token=self.creator_tok, expected_code=403
+        )
+        self.fetch_media(
+            prime_mxc_uri,
+            access_token=self.other_profile_test_user_tok,
+            expected_code=403,
+        )
+
+    def test_user_download_local_media_attached_to_message_event_success(self) -> None:
+        """Test that can local media attached to image event can be viewed"""
+        mxc_uri = self._create_restricted_media(self.creator)
+        room_id = self.helper.create_room_as(self.creator, tok=self.creator_tok)
+
+        # set room history_visibility to joined, otherwise it will be 'shared'
+        self.helper.send_state(
+            room_id=room_id,
+            event_type=EventTypes.RoomHistoryVisibility,
+            body={"history_visibility": HistoryVisibility.JOINED},
+            tok=self.creator_tok,
+        )
+
+        _ = self.helper.join(room_id, self.other_user, tok=self.other_user_tok)
+        # TODO: verify this file info is legit, because it does not match SMALL_PNG. It
+        #  seems to work tho, oddly
+        image = {
+            "body": "test_png_upload",
+            "info": {"h": 1, "mimetype": "image/png", "size": 67, "w": 1},
+            "msgtype": "m.image",
+            "url": str(mxc_uri),
+        }
+        json_body = self.helper.send_event(
+            room_id,
+            "m.room.message",
+            content=image,
+            tok=self.creator_tok,
+            expect_code=200,
+            attach_media_mxc=str(mxc_uri),
+        )
+        assert "event_id" in json_body
+
+        # Both users should be able to see the event
+        self.fetch_media(mxc_uri)
+        self.fetch_media(mxc_uri, access_token=self.other_user_tok)
+
+    def test_user_download_local_media_attached_to_message_event_failure(self) -> None:
+        """Test that can local media attached to image event can be restricted"""
+        mxc_uri = self._create_restricted_media(self.creator)
+        room_id = self.helper.create_room_as(self.creator, tok=self.creator_tok)
+
+        # set room history_visibility to joined
+        self.helper.send_state(
+            room_id=room_id,
+            event_type=EventTypes.RoomHistoryVisibility,
+            body={"history_visibility": HistoryVisibility.JOINED},
+            tok=self.creator_tok,
+        )
+
+        image = {
+            "body": "test_png_upload",
+            "info": {"h": 1, "mimetype": "image/png", "size": 67, "w": 1},
+            "msgtype": "m.image",
+            "url": str(mxc_uri),
+        }
+        json_body = self.helper.send_event(
+            room_id,
+            "m.room.message",
+            content=image,
+            tok=self.creator_tok,
+            expect_code=200,
+            attach_media_mxc=str(mxc_uri),
+        )
+        assert "event_id" in json_body
+
+        # Specifically, join the user AFTER sending the attaching message
+        self.helper.join(room_id, self.other_user, tok=self.other_user_tok)
+
+        self.fetch_media(mxc_uri)
+        # The other user was not in the room at the time the image was sent, so this
+        # should fail.
+        self.fetch_media(mxc_uri, access_token=self.other_user_tok, expected_code=403)
+
+    def test_user_download_local_media_attached_to_state_event_success(self) -> None:
+        """Test that a simple membership avatar is viewable when appropriate"""
+        mxc_uri = self._create_restricted_media(self.creator)
+        room_id = self.helper.create_room_as(self.creator, tok=self.creator_tok)
+
+        # set room history_visibility to joined
+        self.helper.send_state(
+            room_id=room_id,
+            event_type=EventTypes.RoomHistoryVisibility,
+            body={"history_visibility": HistoryVisibility.JOINED},
+            tok=self.creator_tok,
+        )
+
+        _ = self.helper.join(room_id, self.other_user, tok=self.other_user_tok)
+
+        membership_content = {
+            EventContentFields.MEMBERSHIP: Membership.JOIN,
+            "avatar_url": str(mxc_uri),
+        }
+        json_body = self.helper.send_state(
+            room_id,
+            EventTypes.Member,
+            body=membership_content,
+            tok=self.creator_tok,
+            expect_code=200,
+            state_key=self.creator,
+            attach_media_mxc=str(mxc_uri),
+        )
+        assert "event_id" in json_body
+
+        # Both users should be able to see the media
+        self.fetch_media(mxc_uri)
+        self.fetch_media(mxc_uri, access_token=self.other_user_tok)
+
+    def test_user_download_local_media_attached_to_state_event_failure(self) -> None:
+        """Test that a simple membership avatar is restricted when appropriate"""
+        mxc_uri = self._create_restricted_media(self.creator)
+        room_id = self.helper.create_room_as(self.creator, tok=self.creator_tok)
+        # set room history_visibility to joined
+        self.helper.send_state(
+            room_id=room_id,
+            event_type=EventTypes.RoomHistoryVisibility,
+            body={"history_visibility": HistoryVisibility.JOINED},
+            tok=self.creator_tok,
+        )
+
+        membership_content = {
+            EventContentFields.MEMBERSHIP: Membership.JOIN,
+            "avatar_url": str(mxc_uri),
+        }
+        json_body = self.helper.send_state(
+            room_id,
+            EventTypes.Member,
+            body=membership_content,
+            tok=self.creator_tok,
+            expect_code=200,
+            state_key=self.creator,
+            attach_media_mxc=str(mxc_uri),
+        )
+        assert "event_id" in json_body
+
+        _ = self.helper.join(room_id, self.other_user, tok=self.other_user_tok)
+
+        self.fetch_media(mxc_uri)
+        # This user has joined the room and can now see this image. Can't see the
+        # related membership event, but :man-shrug:
+        self.fetch_media(mxc_uri, access_token=self.other_user_tok)

--- a/tests/rest/client/test_media_thumbnail.py
+++ b/tests/rest/client/test_media_thumbnail.py
@@ -1,0 +1,368 @@
+#
+# This file is licensed under the Affero General Public License (AGPL) version 3.
+#
+# Copyright 2025 The Matrix.org Foundation C.I.C.
+# Copyright (C) 2025 Famedly
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# See the GNU Affero General Public License for more details:
+# <https://www.gnu.org/licenses/agpl-3.0.html>.
+#
+# Originally licensed under the Apache License, Version 2.0:
+# <http://www.apache.org/licenses/LICENSE-2.0>.
+#
+
+import io
+from typing import Optional
+
+from matrix_common.types.mxc_uri import MXCUri
+
+from twisted.internet.testing import MemoryReactor
+from twisted.web.resource import Resource
+
+from synapse.api.constants import (
+    EventContentFields,
+    EventTypes,
+    HistoryVisibility,
+    Membership,
+)
+from synapse.rest import admin
+from synapse.rest.client import login, media, room
+from synapse.server import HomeServer
+from synapse.types import JsonDict, UserID
+from synapse.util import Clock
+
+from tests import unittest
+from tests.server import FakeChannel
+from tests.test_utils import SMALL_PNG
+from tests.unittest import override_config
+
+
+class RestrictedResourceThumbnailTestCase(unittest.HomeserverTestCase):
+    """
+    Test the `/thumbnail` media endpoint for restricted media.
+
+    Something to note: rooms here will be set to room history visibility of 'joined'
+    at a minimum, or the media would be visible by default
+    """
+
+    servlets = [
+        media.register_servlets,
+        login.register_servlets,
+        admin.register_servlets,
+        room.register_servlets,
+    ]
+
+    def default_config(self) -> JsonDict:
+        config = super().default_config()
+        config.setdefault("experimental_features", {})
+        config["experimental_features"].update({"msc3911_enabled": True})
+        # This is what the defaults are for both 'crop' and 'scale' as reference
+        # We don't need to set these, but it's good to know
+        # "thumbnail_sizes": [
+        #     {"width": 32, "height": 32, "method": "crop"},
+        #     {"width": 240, "height": 320, "method": "scale"},
+        # ],
+        return config
+
+    def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
+        self.repo = hs.get_media_repository()
+        self.store = hs.get_datastores().main
+        self.creator = self.register_user("creator", "testpass")
+        self.creator_tok = self.login("creator", "testpass")
+        self.other_user = self.register_user("random_user", "testpass")
+        self.other_user_tok = self.login("random_user", "testpass")
+        self.other_profile_test_user = self.register_user(
+            "profile_test_user", "testpass"
+        )
+        self.other_profile_test_user_tok = self.login("profile_test_user", "testpass")
+
+    def create_resource_dict(self) -> dict[str, Resource]:
+        resources = super().create_resource_dict()
+        resources["/_matrix/media"] = self.hs.get_media_repository_resource()
+        return resources
+
+    def _create_restricted_media(self, user: str) -> MXCUri:
+        """
+        Insert our media directly into the database/repo. This creates the necessary
+        rows and sets the media as 'restricted' but does establish any attachments.
+        """
+        mxc_uri = self.get_success(
+            self.repo.create_or_update_content(
+                "image/png",
+                "test_png_upload",
+                io.BytesIO(SMALL_PNG),
+                67,
+                UserID.from_string(user),
+                restricted=True,
+            )
+        )
+        return mxc_uri
+
+    def fetch_thumbnail(
+        self,
+        mxc_uri: MXCUri,
+        method: str = "crop",
+        access_token: Optional[str] = None,
+        expect_code: int = 200,
+    ) -> FakeChannel:
+        """
+        Attempt media retrieval from the `/thumbnail` endpoint. Assert's expected code
+        before returning raw channel
+        """
+        params = "?width=1&height=1&method=" + method
+        channel = self.make_request(
+            "GET",
+            f"/_matrix/client/v1/media/thumbnail/{mxc_uri.server_name}/{mxc_uri.media_id}{params}",
+            access_token=access_token or self.creator_tok,
+        )
+        assert channel.code == expect_code, channel.code
+        return channel
+
+    def test_user_download_local_media_thumbnail_unrestricted(self) -> None:
+        """Test that unrestricted media is not affected"""
+        # Note that 'restricted' is marked as 'False' here
+        content_mxc_uri = self.get_success(
+            self.repo.create_or_update_content(
+                "image/png",
+                "test_png_upload",
+                io.BytesIO(SMALL_PNG),
+                67,
+                UserID.from_string(self.other_user),
+                restricted=False,
+            )
+        )
+        # The assertion of 200 as a response code is part of the function
+        self.fetch_thumbnail(content_mxc_uri)
+        self.fetch_thumbnail(content_mxc_uri, access_token=self.other_user_tok)
+
+    def test_download_local_media_restricted_but_pending_state(self) -> None:
+        """Test originating user can access media even though it is not attached"""
+        mxc_uri = self._create_restricted_media(self.creator)
+
+        # The creator user can see their own media
+        self.fetch_thumbnail(mxc_uri)
+        # But another user can not
+        self.fetch_thumbnail(mxc_uri, access_token=self.other_user_tok, expect_code=403)
+
+    def test_user_download_local_media_attached_to_user_profile_success(self) -> None:
+        """Test retrieving media attached to user's profile"""
+        prime_mxc_uri = self._create_restricted_media(self.creator)
+        other_mxc_uri = self._create_restricted_media(self.other_profile_test_user)
+        # Inject directly to the database, we are not here to test the profile endpoint
+        self.get_success(
+            self.store.set_media_restricted_to_user_profile(
+                prime_mxc_uri.server_name,
+                prime_mxc_uri.media_id,
+                self.creator,
+            )
+        )
+        self.get_success(
+            self.store.set_media_restricted_to_user_profile(
+                other_mxc_uri.server_name,
+                other_mxc_uri.media_id,
+                self.other_profile_test_user,
+            )
+        )
+
+        # Should be able to see their own
+        self.fetch_thumbnail(prime_mxc_uri, access_token=self.creator_tok)
+        self.fetch_thumbnail(
+            other_mxc_uri, access_token=self.other_profile_test_user_tok
+        )
+
+        # Should be able to see each others
+        self.fetch_thumbnail(other_mxc_uri, access_token=self.creator_tok)
+        self.fetch_thumbnail(
+            prime_mxc_uri, access_token=self.other_profile_test_user_tok
+        )
+
+    @override_config(
+        {
+            "limit_profile_requests_to_users_who_share_rooms": True,
+        }
+    )
+    def test_user_download_local_media_attached_to_user_profile_failure(self) -> None:
+        """
+        Test that limiting profile requests works as expected. Specifically, that users
+        that are not sharing a room can not see profile avatars
+        """
+
+        prime_mxc_uri = self._create_restricted_media(self.creator)
+        other_mxc_uri = self._create_restricted_media(self.other_profile_test_user)
+        # Inject directly to the database, we are not here to test the profile endpoint
+        self.get_success(
+            self.store.set_media_restricted_to_user_profile(
+                prime_mxc_uri.server_name,
+                prime_mxc_uri.media_id,
+                self.creator,
+            )
+        )
+        self.get_success(
+            self.store.set_media_restricted_to_user_profile(
+                other_mxc_uri.server_name,
+                other_mxc_uri.media_id,
+                self.other_profile_test_user,
+            )
+        )
+
+        # Should be able to see their own
+        self.fetch_thumbnail(prime_mxc_uri, access_token=self.creator_tok)
+        self.fetch_thumbnail(
+            other_mxc_uri, access_token=self.other_profile_test_user_tok
+        )
+
+        # Should NOT be able to see each others, since the limitation setting is enabled
+        self.fetch_thumbnail(
+            other_mxc_uri, access_token=self.creator_tok, expect_code=403
+        )
+        self.fetch_thumbnail(
+            prime_mxc_uri,
+            access_token=self.other_profile_test_user_tok,
+            expect_code=403,
+        )
+
+    def test_users_download_local_media_attached_to_message_event_success(self) -> None:
+        """Test that can local media attached to image event can be viewed"""
+        mxc_uri = self._create_restricted_media(self.creator)
+        room_id = self.helper.create_room_as(self.creator, tok=self.creator_tok)
+
+        # set room history_visibility to joined, otherwise it will be 'shared'
+        self.helper.send_state(
+            room_id=room_id,
+            event_type=EventTypes.RoomHistoryVisibility,
+            body={"history_visibility": HistoryVisibility.JOINED},
+            tok=self.creator_tok,
+        )
+
+        _ = self.helper.join(room_id, self.other_user, tok=self.other_user_tok)
+        # TODO: verify this file info is legit, because it does not match SMALL_PNG. It
+        #  seems to work tho, oddly
+        image = {
+            "body": "test_png_upload",
+            "info": {"h": 1, "mimetype": "image/png", "size": 67, "w": 1},
+            "msgtype": "m.image",
+            "url": str(mxc_uri),
+        }
+        json_body = self.helper.send_event(
+            room_id,
+            "m.room.message",
+            content=image,
+            tok=self.creator_tok,
+            expect_code=200,
+            attach_media_mxc=str(mxc_uri),
+        )
+        assert "event_id" in json_body
+
+        # Both users should be able to see the event
+        self.fetch_thumbnail(mxc_uri)
+        self.fetch_thumbnail(mxc_uri, access_token=self.other_user_tok)
+
+    def test_users_download_local_media_attached_to_message_event_failure(self) -> None:
+        """Test that can local media attached to image event can be restricted"""
+        mxc_uri = self._create_restricted_media(self.creator)
+        room_id = self.helper.create_room_as(self.creator, tok=self.creator_tok)
+
+        # set room history_visibility to joined
+        self.helper.send_state(
+            room_id=room_id,
+            event_type=EventTypes.RoomHistoryVisibility,
+            body={"history_visibility": HistoryVisibility.JOINED},
+            tok=self.creator_tok,
+        )
+
+        image = {
+            "body": "test_png_upload",
+            "info": {"h": 1, "mimetype": "image/png", "size": 67, "w": 1},
+            "msgtype": "m.image",
+            "url": str(mxc_uri),
+        }
+        json_body = self.helper.send_event(
+            room_id,
+            "m.room.message",
+            content=image,
+            tok=self.creator_tok,
+            expect_code=200,
+            attach_media_mxc=str(mxc_uri),
+        )
+        assert "event_id" in json_body
+
+        # Specifically, join the user AFTER sending the attaching message
+        self.helper.join(room_id, self.other_user, tok=self.other_user_tok)
+
+        self.fetch_thumbnail(mxc_uri)
+        # The other user was not in the room at the time the image was sent, so this
+        # should fail.
+        self.fetch_thumbnail(mxc_uri, access_token=self.other_user_tok, expect_code=403)
+
+    def test_user_download_local_media_attached_to_state_event_success(self) -> None:
+        """Test that a simple membership avatar is viewable when appropriate"""
+        mxc_uri = self._create_restricted_media(self.creator)
+        room_id = self.helper.create_room_as(self.creator, tok=self.creator_tok)
+
+        # set room history_visibility to joined
+        self.helper.send_state(
+            room_id=room_id,
+            event_type=EventTypes.RoomHistoryVisibility,
+            body={"history_visibility": HistoryVisibility.JOINED},
+            tok=self.creator_tok,
+        )
+
+        _ = self.helper.join(room_id, self.other_user, tok=self.other_user_tok)
+
+        membership_content = {
+            EventContentFields.MEMBERSHIP: Membership.JOIN,
+            "avatar_url": str(mxc_uri),
+        }
+        json_body = self.helper.send_state(
+            room_id,
+            EventTypes.Member,
+            body=membership_content,
+            tok=self.creator_tok,
+            expect_code=200,
+            state_key=self.creator,
+            attach_media_mxc=str(mxc_uri),
+        )
+        assert "event_id" in json_body
+
+        # Both users should be able to see the media
+        self.fetch_thumbnail(mxc_uri)
+        self.fetch_thumbnail(mxc_uri, access_token=self.other_user_tok)
+
+    def test_user_download_local_media_attached_to_state_event_failure(self) -> None:
+        """Test that a simple membership avatar is restricted when appropriate"""
+        mxc_uri = self._create_restricted_media(self.creator)
+        room_id = self.helper.create_room_as(self.creator, tok=self.creator_tok)
+        # set room history_visibility to joined
+        self.helper.send_state(
+            room_id=room_id,
+            event_type=EventTypes.RoomHistoryVisibility,
+            body={"history_visibility": HistoryVisibility.JOINED},
+            tok=self.creator_tok,
+        )
+
+        membership_content = {
+            EventContentFields.MEMBERSHIP: Membership.JOIN,
+            "avatar_url": str(mxc_uri),
+        }
+        json_body = self.helper.send_state(
+            room_id,
+            EventTypes.Member,
+            body=membership_content,
+            tok=self.creator_tok,
+            expect_code=200,
+            state_key=self.creator,
+            attach_media_mxc=str(mxc_uri),
+        )
+        assert "event_id" in json_body
+
+        _ = self.helper.join(room_id, self.other_user, tok=self.other_user_tok)
+
+        self.fetch_thumbnail(mxc_uri)
+        # This user has joined the room and can now see this image. Can't see the
+        # related membership event, but :man-shrug:
+        self.fetch_thumbnail(mxc_uri, access_token=self.other_user_tok)


### PR DESCRIPTION
# Linked Media MSC3911 AP7: Permission checks for download and thumbnail endpoints

fixes: famedly/product-management#3357

* [x] unrestricted media should be downloadable by everyone (depending on their authentication)
* [x] If media is restricted, but not attached yet, it should only be accessible by the uploader.
* [x] Media attached to profiles should be downloadable, if the user can see that profile. Usually that is allowed by everyone, but if profile lookups are restricted to shared rooms, it will be restricted to users that share rooms.
Media attached to events should be downloadable, if the user can see that event. The rules for that are tricky:
  * [x] If the event is a message event, normal history visibility rules apply.
  * [x] If the event is a state event, it should be visible, if the event was part of the current state at any point the user would have had access to the current state or if the history visibility rules make the event visible. The current state rule even needs to apply to stripped state events for invites, public rooms, etc. This is quite tricky and might need to be split up into several issues.
* [x] If any other (unknown) restrictions are present, the media should be inaccessible.
* [x] These restrictions should only be applied, when the MSC is enabled.
