### PR TITLE
MSC3911 AP9: Media copy endpoint follow up

### DIFF
--- a/synapse/api/errors.py
+++ b/synapse/api/errors.py
@@ -245,6 +245,13 @@ class InvalidAPICallError(SynapseError):
         super().__init__(HTTPStatus.BAD_REQUEST, msg, Codes.BAD_JSON)
 
 
+class UnauthorizedRequestAPICallError(SynapseError):
+    """Error raised when a request was not allowed due to authorization"""
+
+    def __init__(self, msg: str):
+        super().__init__(HTTPStatus.FORBIDDEN, msg, Codes.UNAUTHORIZED)
+
+
 class InvalidProxyCredentialsError(SynapseError):
     """Error raised when the proxy credentials are invalid."""
 

--- a/synapse/media/media_repository.py
+++ b/synapse/media/media_repository.py
@@ -445,6 +445,8 @@ class MediaRepository:
 
             # The file has been uploaded, so stop looping
             if media_info.media_length is not None:
+                if isinstance(request.requester, Requester):
+                    await self.is_media_visible(request.requester.user, media_info)
                 return media_info
 
             # Check if the media ID has expired and still hasn't been uploaded to.

--- a/synapse/media/media_repository.py
+++ b/synapse/media/media_repository.py
@@ -569,6 +569,7 @@ class MediaRepository:
         media_id: str,
         name: Optional[str],
         max_timeout_ms: int,
+        requester: Optional[Requester] = None,
         allow_authenticated: bool = True,
         federation: bool = False,
     ) -> None:
@@ -582,6 +583,8 @@ class MediaRepository:
                 the filename in the Content-Disposition header of the response.
             max_timeout_ms: the maximum number of milliseconds to wait for the
                 media to be uploaded.
+            requester: The user making the request, to verify restricted media. Only
+                used for local users, not over federation
             allow_authenticated: whether media marked as authenticated may be served to this request
             federation: whether the local media being fetched is for a federation request
 
@@ -645,6 +648,7 @@ class MediaRepository:
         max_timeout_ms: int,
         ip_address: str,
         use_federation_endpoint: bool,
+        requester: Optional[Requester] = None,
         allow_authenticated: bool = True,
     ) -> None:
         """Respond to requests for remote media.
@@ -660,6 +664,8 @@ class MediaRepository:
             ip_address: the IP address of the requester
             use_federation_endpoint: whether to request the remote media over the new
                 federation `/download` endpoint
+            requester: The user making the request, to verify restricted media. Only
+                used for local users, not over federation
             allow_authenticated: whether media marked as authenticated may be served to this
                 request
 
@@ -694,6 +700,7 @@ class MediaRepository:
                 ip_address,
                 use_federation_endpoint,
                 allow_authenticated,
+                requester,
             )
 
         # Check if the media is cached on the client, if so return 304. We need
@@ -728,6 +735,7 @@ class MediaRepository:
         ip_address: str,
         use_federation: bool,
         allow_authenticated: bool,
+        requester: Optional[Requester] = None,
     ) -> RemoteMedia:
         """Gets the media info associated with the remote file, downloading
         if necessary.
@@ -742,6 +750,8 @@ class MediaRepository:
                 over the federation `/download` endpoint
             allow_authenticated: whether media marked as authenticated may be served to this
                 request
+            requester: The user making the request, to verify restricted media. Only
+                used for local users, not over federation
 
         Returns:
             The media info of the file
@@ -764,6 +774,7 @@ class MediaRepository:
                 ip_address,
                 use_federation,
                 allow_authenticated,
+                requester,
             )
 
         # Ensure we actually use the responder so that it releases resources
@@ -782,6 +793,7 @@ class MediaRepository:
         ip_address: str,
         use_federation_endpoint: bool,
         allow_authenticated: bool,
+        requester: Optional[Requester] = None,
     ) -> Tuple[Optional[Responder], RemoteMedia]:
         """Looks for media in local cache, if not there then attempt to
         download from remote server.
@@ -797,6 +809,9 @@ class MediaRepository:
             ip_address: the IP address of the requester
             use_federation_endpoint: whether to request the remote media over the new federation
             /download endpoint
+            allow_authenticated:
+            requester: The user making the request, to verify restricted media. Only
+                used for local users, not over federation
 
         Returns:
             A tuple of responder and the media info of the file.

--- a/synapse/media/media_repository.py
+++ b/synapse/media/media_repository.py
@@ -473,12 +473,9 @@ class MediaRepository:
         """
 
         if not self.enable_media_restriction:
-            # If media restrictions are not enabled, do not restrict
-            logger.debug("Media restriction is not enabled")
             return
 
         if not media_info_object.restricted:
-            logger.debug("Media does not restricted visibility")
             return
 
         if not media_info_object.attachments:
@@ -489,35 +486,24 @@ class MediaRepository:
             ):
                 return
 
-            logger.debug("Media is restricted, but does not have attachments yet")
             # It was restricted, but no attachments. Deny
-            # TODO: decide if the server origin needs to be included here
             raise UnauthorizedRequestAPICallError(
                 f"Media requested ('{media_info_object.media_id}') is restricted"
             )
 
-        # Should have checked before this function was called if the requester was
-        # the same as the uploader, so we don't do that again.
-        logger.debug("Found attachments for media: %r", media_info_object.attachments)
         attached_event_id = media_info_object.attachments.event_id
         attached_profile_user_id = media_info_object.attachments.profile_user_id
 
         if attached_event_id:
-            logger.debug("Found media attached to event ID: %r", attached_event_id)
             event_base = await self.store.get_event(attached_event_id)
             storage_controllers = self.hs.get_storage_controllers()
 
-            # Use the filter_send_to_client=False argument to check that a user can see
-            # the state at a given point. This should work for our purposes.
-            # TODO: check that is the same as stripped state and is appropriate
-            logger.debug("About to check filtering for event id: %r", attached_event_id)
             filtered_events = await filter_events_for_client(
                 storage_controllers,
                 requesting_user.to_string(),
                 [event_base],
                 # filter_send_to_client=not event_base.is_state(),
             )
-            logger.debug("Filtered events: %r", filtered_events)
             if len(filtered_events) > 0:
                 return
 

--- a/synapse/media/thumbnailer.py
+++ b/synapse/media/thumbnailer.py
@@ -42,6 +42,7 @@ from synapse.media._base import (
 )
 from synapse.media.media_storage import FileResponder, MediaStorage
 from synapse.storage.databases.main.media_repository import LocalMedia
+from synapse.types import Requester
 
 if TYPE_CHECKING:
     from synapse.media.media_repository import MediaRepository
@@ -281,6 +282,7 @@ class ThumbnailProvider:
         m_type: str,
         max_timeout_ms: int,
         for_federation: bool,
+        requester: Optional[Requester] = None,
         allow_authenticated: bool = True,
     ) -> None:
         media_info = await self.media_repo.get_local_media_info(
@@ -326,6 +328,7 @@ class ThumbnailProvider:
         desired_type: str,
         max_timeout_ms: int,
         for_federation: bool,
+        requester: Optional[Requester] = None,
         allow_authenticated: bool = True,
     ) -> None:
         media_info = await self.media_repo.get_local_media_info(
@@ -421,6 +424,7 @@ class ThumbnailProvider:
         max_timeout_ms: int,
         ip_address: str,
         use_federation: bool,
+        requester: Optional[Requester] = None,
         allow_authenticated: bool = True,
     ) -> None:
         media_info = await self.media_repo.get_remote_media_info(
@@ -430,6 +434,7 @@ class ThumbnailProvider:
             ip_address,
             use_federation,
             allow_authenticated,
+            requester,
         )
         if not media_info:
             respond_404(request)
@@ -503,6 +508,7 @@ class ThumbnailProvider:
         max_timeout_ms: int,
         ip_address: str,
         use_federation: bool,
+        requester: Optional[Requester] = None,
         allow_authenticated: bool = True,
     ) -> None:
         # TODO: Don't download the whole remote file
@@ -515,6 +521,7 @@ class ThumbnailProvider:
             ip_address,
             use_federation,
             allow_authenticated,
+            requester,
         )
         if not media_info:
             return

--- a/synapse/media/thumbnailer.py
+++ b/synapse/media/thumbnailer.py
@@ -271,6 +271,7 @@ class ThumbnailProvider:
         self.media_storage = media_storage
         self.store = hs.get_datastores().main
         self.dynamic_thumbnails = hs.config.media.dynamic_thumbnails
+        self.enable_media_restriction = self.hs.config.experimental.msc3911_enabled
 
     async def respond_local_thumbnail(
         self,
@@ -296,6 +297,12 @@ class ThumbnailProvider:
         if self.hs.config.media.enable_authenticated_media and not allow_authenticated:
             if media_info.authenticated:
                 raise NotFoundError()
+
+        # if MSC3911 is enabled, check visibility of the media for the user
+        if self.enable_media_restriction and requester is not None:
+            user_id = requester.user
+            # This will raise directly back to the client if not visible
+            await self.media_repo.is_media_visible(user_id, media_info)
 
         # Once we've checked auth we can return early if the media is cached on
         # the client
@@ -342,6 +349,12 @@ class ThumbnailProvider:
         if self.hs.config.media.enable_authenticated_media and not allow_authenticated:
             if media_info.authenticated:
                 raise NotFoundError()
+
+        # if MSC3911 is enabled, check visibility of the media for the user
+        if self.enable_media_restriction and requester is not None:
+            user_id = requester.user
+            # This will raise directly back to the client if not visible
+            await self.media_repo.is_media_visible(user_id, media_info)
 
         # Once we've checked auth we can return early if the media is cached on
         # the client
@@ -447,6 +460,12 @@ class ThumbnailProvider:
                 respond_404(request)
                 return
 
+        # if MSC3911 is enabled, check visibility of the media for the user
+        if self.enable_media_restriction and requester is not None:
+            user_id = requester.user
+            # This will raise directly back to the client if not visible
+            await self.media_repo.is_media_visible(user_id, media_info)
+
         # Check if the media is cached on the client, if so return 304.
         if check_for_cached_entry_and_respond(request):
             return
@@ -531,6 +550,12 @@ class ThumbnailProvider:
         if self.hs.config.media.enable_authenticated_media and not allow_authenticated:
             if media_info.authenticated:
                 raise NotFoundError()
+
+        # if MSC3911 is enabled, check visibility of the media for the user
+        if self.enable_media_restriction and requester is not None:
+            user_id = requester.user
+            # This will raise directly back to the client if not visible
+            await self.media_repo.is_media_visible(user_id, media_info)
 
         # Check if the media is cached on the client, if so return 304.
         if check_for_cached_entry_and_respond(request):

--- a/synapse/rest/client/media.py
+++ b/synapse/rest/client/media.py
@@ -159,7 +159,7 @@ class ThumbnailResource(RestServlet):
     ) -> None:
         # Validate the server name, raising if invalid
         parse_and_validate_server_name(server_name)
-        await self.auth.get_user_by_req(request, allow_guest=True)
+        requester = await self.auth.get_user_by_req(request, allow_guest=True)
 
         set_cors_headers(request)
         set_corp_headers(request)
@@ -184,6 +184,7 @@ class ThumbnailResource(RestServlet):
                     m_type,
                     max_timeout_ms,
                     False,
+                    requester,
                 )
             else:
                 await self.thumbnailer.respond_local_thumbnail(
@@ -195,6 +196,7 @@ class ThumbnailResource(RestServlet):
                     m_type,
                     max_timeout_ms,
                     False,
+                    requester,
                 )
             self.media_repo.mark_recently_accessed(None, media_id)
         else:
@@ -223,6 +225,7 @@ class ThumbnailResource(RestServlet):
                 max_timeout_ms,
                 ip_address,
                 True,
+                requester,
             )
             self.media_repo.mark_recently_accessed(server_name, media_id)
 
@@ -250,7 +253,7 @@ class DownloadResource(RestServlet):
         # Validate the server name, raising if invalid
         parse_and_validate_server_name(server_name)
 
-        await self.auth.get_user_by_req(request, allow_guest=True)
+        requester = await self.auth.get_user_by_req(request, allow_guest=True)
 
         set_cors_headers(request)
         set_corp_headers(request)
@@ -274,7 +277,7 @@ class DownloadResource(RestServlet):
 
         if self._is_mine_server_name(server_name):
             await self.media_repo.get_local_media(
-                request, media_id, file_name, max_timeout_ms
+                request, media_id, file_name, max_timeout_ms, requester
             )
         else:
             ip_address = request.getClientAddress().host
@@ -286,6 +289,7 @@ class DownloadResource(RestServlet):
                 max_timeout_ms,
                 ip_address,
                 True,
+                requester,
             )
 
 

--- a/synapse/storage/databases/main/media_repository.py
+++ b/synapse/storage/databases/main/media_repository.py
@@ -757,7 +757,8 @@ class MediaRepositoryStore(MediaRepositoryBackgroundUpdateStore):
         if row is None:
             return row
         restriction_info = None
-        if row[9] is not None and row[9] is True:
+
+        if row[9] is not None and row[9]:
             restriction_info = await self.get_media_restrictions(origin, media_id)
 
         return RemoteMedia(

--- a/tests/rest/client/test_media.py
+++ b/tests/rest/client/test_media.py
@@ -3655,8 +3655,6 @@ class RestrictedMediaVisibilityTestCase(unittest.HomeserverTestCase):
     def send_membership_with_attached_media(
         self, room_id: str, mxc_uri: MXCUri, tok: Optional[str] = None
     ) -> FakeChannel:
-        # TODO: maybe switch this to direct database injection? We are not here to test
-        #  endpoints directly, just logic
         channel1 = self.make_request(
             "PUT",
             f"/rooms/{room_id}/state/m.room.member/{self.alice_user_id}?org.matrix.msc3911.attach_media={str(mxc_uri)}",

--- a/tests/rest/client/test_media.py
+++ b/tests/rest/client/test_media.py
@@ -3388,14 +3388,14 @@ class RestrictedMediaVisibilityTestCase(unittest.HomeserverTestCase):
         initial_room_avatar_mxc: Optional[MXCUri] = None,
         invite_list: Optional[List[str]] = None,
     ) -> str:
-        initial_state_list = []
-        initial_state_list.append(
+        initial_state_list = [
             {
                 "type": EventTypes.RoomHistoryVisibility,
                 "state_key": "",
                 "content": {"history_visibility": visibility},
             }
-        )
+        ]
+
         if initial_room_avatar_mxc:
             # Because of the order that room events are created in, if the room avatar
             # does not come before the history visibility event, it will not be visible

--- a/tests/rest/client/test_media.py
+++ b/tests/rest/client/test_media.py
@@ -3125,7 +3125,7 @@ class RestrictedResourceUploadTestCase(unittest.HomeserverTestCase):
             f"/_matrix/client/v1/media/download/{self.hs.hostname}/{media_id}",
             access_token=self.creator_tok,
         )
-        assert channel.code == 200
+        assert channel.code == 200, channel.json_body
 
         # The other user cannot download the restricted resource in pending state.
         channel = self.make_request(
@@ -3133,7 +3133,7 @@ class RestrictedResourceUploadTestCase(unittest.HomeserverTestCase):
             f"/_matrix/client/v1/media/download/{self.hs.hostname}/{media_id}",
             access_token=self.other_user_tok,
         )
-        assert channel.code == 404
+        assert channel.code == 403, channel.json_body
 
     def test_async_upload_restricted_resource(self) -> None:
         """
@@ -3177,7 +3177,7 @@ class RestrictedResourceUploadTestCase(unittest.HomeserverTestCase):
             f"/_matrix/client/v1/media/download/{self.hs.hostname}/{media_id}",
             access_token=self.creator_tok,
         )
-        assert channel.code == 200
+        assert channel.code == 200, channel.json_body
 
         # The other user cannot download the restricted resource.
         channel = self.make_request(
@@ -3185,7 +3185,7 @@ class RestrictedResourceUploadTestCase(unittest.HomeserverTestCase):
             f"/_matrix/client/v1/media/download/{self.hs.hostname}/{media_id}",
             access_token=self.other_user_tok,
         )
-        assert channel.code == 404
+        assert channel.code == 403, channel.json_body
 
 
 class CopyRestrictedResource(unittest.HomeserverTestCase):

--- a/tests/rest/client/test_media.py
+++ b/tests/rest/client/test_media.py
@@ -4096,8 +4096,6 @@ class RestrictedMediaVisibilityTestCase(unittest.HomeserverTestCase):
             leaving_user_id, second_media_object, expected_after_result_bool
         )
 
-    # TODO: Test redactions too
-
     def test_global_profile_is_visible(self) -> None:
         """
         Test that a profile avatar that is not from a membership event is viewable if not limited

--- a/tests/rest/client/test_media.py
+++ b/tests/rest/client/test_media.py
@@ -3465,6 +3465,9 @@ class RestrictedMediaVisibilityTestCase(unittest.HomeserverTestCase):
     ) -> None:
         # If the expectation is True, it is expected the function is a success
         # If the expectation is False, it is expected to raise the exception
+        #
+        # It may be easier to think of True and False here as Visible and Not Visible in
+        # the context of this TestCase.
         if expected_bool:
             # As a note about nullcontext manager: Support for async context behavior
             # was added in python 3.10. However, we don't need that even when testing an

--- a/tests/rest/client/test_media_download.py
+++ b/tests/rest/client/test_media_download.py
@@ -1,0 +1,344 @@
+#
+# This file is licensed under the Affero General Public License (AGPL) version 3.
+#
+# Copyright 2025 The Matrix.org Foundation C.I.C.
+# Copyright (C) 2025 Famedly
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# See the GNU Affero General Public License for more details:
+# <https://www.gnu.org/licenses/agpl-3.0.html>.
+#
+# Originally licensed under the Apache License, Version 2.0:
+# <http://www.apache.org/licenses/LICENSE-2.0>.
+#
+
+import io
+from typing import Optional
+
+from matrix_common.types.mxc_uri import MXCUri
+
+from twisted.test.proto_helpers import MemoryReactor
+from twisted.web.resource import Resource
+
+from synapse.api.constants import (
+    EventContentFields,
+    EventTypes,
+    HistoryVisibility,
+    Membership,
+)
+from synapse.rest import admin
+from synapse.rest.client import login, media, room
+from synapse.server import HomeServer
+from synapse.types import JsonDict, UserID
+from synapse.util import Clock
+
+from tests import unittest
+from tests.test_utils import SMALL_PNG
+from tests.unittest import override_config
+
+
+class RestrictedResourceDownloadTestCase(unittest.HomeserverTestCase):
+    """
+    Test the `/download` media endpoint for restricted media.
+
+    Something to note: rooms here will be set to room history visibility of 'joined'
+    at a minimum, or the media would be visible by default
+    """
+
+    servlets = [
+        media.register_servlets,
+        login.register_servlets,
+        admin.register_servlets,
+        room.register_servlets,
+    ]
+
+    def default_config(self) -> JsonDict:
+        config = super().default_config()
+        config.setdefault("experimental_features", {})
+        config["experimental_features"].update({"msc3911_enabled": True})
+        return config
+
+    def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
+        self.repo = hs.get_media_repository()
+        self.store = hs.get_datastores().main
+        self.creator = self.register_user("creator", "testpass")
+        self.creator_tok = self.login("creator", "testpass")
+        self.other_user = self.register_user("random_user", "testpass")
+        self.other_user_tok = self.login("random_user", "testpass")
+        self.other_profile_test_user = self.register_user(
+            "profile_test_user", "testpass"
+        )
+        self.other_profile_test_user_tok = self.login("profile_test_user", "testpass")
+
+    def create_resource_dict(self) -> dict[str, Resource]:
+        resources = super().create_resource_dict()
+        resources["/_matrix/media"] = self.hs.get_media_repository_resource()
+        return resources
+
+    def _create_restricted_media(self, user: str) -> MXCUri:
+        mxc_uri = self.get_success(
+            self.repo.create_or_update_content(
+                "image/png",
+                "test_png_upload",
+                io.BytesIO(SMALL_PNG),
+                67,
+                UserID.from_string(user),
+                restricted=True,
+            )
+        )
+        return mxc_uri
+
+    def fetch_media(
+        self,
+        mxc_uri: MXCUri,
+        access_token: Optional[str] = None,
+        expected_code: int = 200,
+    ) -> None:
+        """
+        Test retrieving the media. We do not care about the content of the media, just
+        that the response is correct
+        """
+        channel = self.make_request(
+            "GET",
+            f"/_matrix/client/v1/media/download/{mxc_uri.server_name}/{mxc_uri.media_id}",
+            access_token=access_token or self.creator_tok,
+        )
+        assert channel.code == expected_code, channel.code
+
+    def test_user_download_local_media_unrestricted(self) -> None:
+        """Test that unrestricted media is not affected"""
+        mxc_uri = self.get_success(
+            self.repo.create_or_update_content(
+                "image/png",
+                "test_png_upload",
+                io.BytesIO(SMALL_PNG),
+                67,
+                UserID.from_string(self.other_user),
+                restricted=False,
+            )
+        )
+        # The assertion of 200 as a response code is part of the function
+        self.fetch_media(mxc_uri)
+        self.fetch_media(mxc_uri, access_token=self.other_user_tok)
+
+    def test_download_local_media_restricted_but_pending_state(self) -> None:
+        """Test originating user can access media even though it is not attached"""
+        mxc_uri = self._create_restricted_media(self.creator)
+        # The creator user can see their own media
+        self.fetch_media(mxc_uri)
+        # But another user can not
+        self.fetch_media(mxc_uri, access_token=self.other_user_tok, expected_code=403)
+
+    def test_user_download_local_media_attached_to_user_profile_success(self) -> None:
+        """Test retrieving media attached to user's profile"""
+        prime_mxc_uri = self._create_restricted_media(self.creator)
+        other_mxc_uri = self._create_restricted_media(self.other_profile_test_user)
+        # Inject directly to the database, we are not here to test the profile endpoint
+        self.get_success(
+            self.store.set_media_restricted_to_user_profile(
+                prime_mxc_uri.server_name,
+                prime_mxc_uri.media_id,
+                self.creator,
+            )
+        )
+        self.get_success(
+            self.store.set_media_restricted_to_user_profile(
+                other_mxc_uri.server_name,
+                other_mxc_uri.media_id,
+                self.other_profile_test_user,
+            )
+        )
+
+        # Should be able to see their own
+        self.fetch_media(prime_mxc_uri, access_token=self.creator_tok)
+        self.fetch_media(other_mxc_uri, access_token=self.other_profile_test_user_tok)
+
+        # Should be able to see each others
+        self.fetch_media(other_mxc_uri, access_token=self.creator_tok)
+        self.fetch_media(prime_mxc_uri, access_token=self.other_profile_test_user_tok)
+
+    @override_config(
+        {
+            "limit_profile_requests_to_users_who_share_rooms": True,
+        }
+    )
+    def test_user_download_local_media_attached_to_user_profile_failure(self) -> None:
+        """
+        Test that limiting profile requests works as expected. Specifically, that users
+        that are not sharing a room can not see profile avatars
+        """
+
+        prime_mxc_uri = self._create_restricted_media(self.creator)
+        other_mxc_uri = self._create_restricted_media(self.other_profile_test_user)
+        # Inject directly to the database, we are not here to test the profile endpoint
+        self.get_success(
+            self.store.set_media_restricted_to_user_profile(
+                prime_mxc_uri.server_name,
+                prime_mxc_uri.media_id,
+                self.creator,
+            )
+        )
+        self.get_success(
+            self.store.set_media_restricted_to_user_profile(
+                other_mxc_uri.server_name,
+                other_mxc_uri.media_id,
+                self.other_profile_test_user,
+            )
+        )
+
+        # Should be able to see their own
+        self.fetch_media(prime_mxc_uri, access_token=self.creator_tok)
+        self.fetch_media(other_mxc_uri, access_token=self.other_profile_test_user_tok)
+
+        # Should NOT be able to see each others, since the limitation setting is enabled
+        self.fetch_media(
+            other_mxc_uri, access_token=self.creator_tok, expected_code=403
+        )
+        self.fetch_media(
+            prime_mxc_uri,
+            access_token=self.other_profile_test_user_tok,
+            expected_code=403,
+        )
+
+    def test_user_download_local_media_attached_to_message_event_success(self) -> None:
+        """Test that can local media attached to image event can be viewed"""
+        mxc_uri = self._create_restricted_media(self.creator)
+        room_id = self.helper.create_room_as(self.creator, tok=self.creator_tok)
+
+        # set room history_visibility to joined, otherwise it will be 'shared'
+        self.helper.send_state(
+            room_id=room_id,
+            event_type=EventTypes.RoomHistoryVisibility,
+            body={"history_visibility": HistoryVisibility.JOINED},
+            tok=self.creator_tok,
+        )
+
+        _ = self.helper.join(room_id, self.other_user, tok=self.other_user_tok)
+        # TODO: verify this file info is legit, because it does not match SMALL_PNG. It
+        #  seems to work tho, oddly
+        image = {
+            "body": "test_png_upload",
+            "info": {"h": 1, "mimetype": "image/png", "size": 67, "w": 1},
+            "msgtype": "m.image",
+            "url": str(mxc_uri),
+        }
+        json_body = self.helper.send_event(
+            room_id,
+            "m.room.message",
+            content=image,
+            tok=self.creator_tok,
+            expect_code=200,
+            attach_media_mxc=str(mxc_uri),
+        )
+        assert "event_id" in json_body
+
+        # Both users should be able to see the event
+        self.fetch_media(mxc_uri)
+        self.fetch_media(mxc_uri, access_token=self.other_user_tok)
+
+    def test_user_download_local_media_attached_to_message_event_failure(self) -> None:
+        """Test that can local media attached to image event can be restricted"""
+        mxc_uri = self._create_restricted_media(self.creator)
+        room_id = self.helper.create_room_as(self.creator, tok=self.creator_tok)
+
+        # set room history_visibility to joined
+        self.helper.send_state(
+            room_id=room_id,
+            event_type=EventTypes.RoomHistoryVisibility,
+            body={"history_visibility": HistoryVisibility.JOINED},
+            tok=self.creator_tok,
+        )
+
+        image = {
+            "body": "test_png_upload",
+            "info": {"h": 1, "mimetype": "image/png", "size": 67, "w": 1},
+            "msgtype": "m.image",
+            "url": str(mxc_uri),
+        }
+        json_body = self.helper.send_event(
+            room_id,
+            "m.room.message",
+            content=image,
+            tok=self.creator_tok,
+            expect_code=200,
+            attach_media_mxc=str(mxc_uri),
+        )
+        assert "event_id" in json_body
+
+        # Specifically, join the user AFTER sending the attaching message
+        self.helper.join(room_id, self.other_user, tok=self.other_user_tok)
+
+        self.fetch_media(mxc_uri)
+        # The other user was not in the room at the time the image was sent, so this
+        # should fail.
+        self.fetch_media(mxc_uri, access_token=self.other_user_tok, expected_code=403)
+
+    def test_user_download_local_media_attached_to_state_event_success(self) -> None:
+        """Test that a simple membership avatar is viewable when appropriate"""
+        mxc_uri = self._create_restricted_media(self.creator)
+        room_id = self.helper.create_room_as(self.creator, tok=self.creator_tok)
+
+        # set room history_visibility to joined
+        self.helper.send_state(
+            room_id=room_id,
+            event_type=EventTypes.RoomHistoryVisibility,
+            body={"history_visibility": HistoryVisibility.JOINED},
+            tok=self.creator_tok,
+        )
+
+        _ = self.helper.join(room_id, self.other_user, tok=self.other_user_tok)
+
+        membership_content = {
+            EventContentFields.MEMBERSHIP: Membership.JOIN,
+            "avatar_url": str(mxc_uri),
+        }
+        json_body = self.helper.send_state(
+            room_id,
+            EventTypes.Member,
+            body=membership_content,
+            tok=self.creator_tok,
+            expect_code=200,
+            state_key=self.creator,
+            attach_media_mxc=str(mxc_uri),
+        )
+        assert "event_id" in json_body
+
+        # Both users should be able to see the media
+        self.fetch_media(mxc_uri)
+        self.fetch_media(mxc_uri, access_token=self.other_user_tok)
+
+    def test_user_download_local_media_attached_to_state_event_failure(self) -> None:
+        """Test that a simple membership avatar is restricted when appropriate"""
+        mxc_uri = self._create_restricted_media(self.creator)
+        room_id = self.helper.create_room_as(self.creator, tok=self.creator_tok)
+        # set room history_visibility to joined
+        self.helper.send_state(
+            room_id=room_id,
+            event_type=EventTypes.RoomHistoryVisibility,
+            body={"history_visibility": HistoryVisibility.JOINED},
+            tok=self.creator_tok,
+        )
+
+        membership_content = {
+            EventContentFields.MEMBERSHIP: Membership.JOIN,
+            "avatar_url": str(mxc_uri),
+        }
+        json_body = self.helper.send_state(
+            room_id,
+            EventTypes.Member,
+            body=membership_content,
+            tok=self.creator_tok,
+            expect_code=200,
+            state_key=self.creator,
+            attach_media_mxc=str(mxc_uri),
+        )
+        assert "event_id" in json_body
+
+        _ = self.helper.join(room_id, self.other_user, tok=self.other_user_tok)
+
+        self.fetch_media(mxc_uri)
+        self.fetch_media(mxc_uri, access_token=self.other_user_tok, expected_code=403)

--- a/tests/rest/client/test_media_thumbnail.py
+++ b/tests/rest/client/test_media_thumbnail.py
@@ -1,0 +1,366 @@
+#
+# This file is licensed under the Affero General Public License (AGPL) version 3.
+#
+# Copyright 2025 The Matrix.org Foundation C.I.C.
+# Copyright (C) 2025 Famedly
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# See the GNU Affero General Public License for more details:
+# <https://www.gnu.org/licenses/agpl-3.0.html>.
+#
+# Originally licensed under the Apache License, Version 2.0:
+# <http://www.apache.org/licenses/LICENSE-2.0>.
+#
+
+import io
+from typing import Optional
+
+from matrix_common.types.mxc_uri import MXCUri
+
+from twisted.internet.testing import MemoryReactor
+from twisted.web.resource import Resource
+
+from synapse.api.constants import (
+    EventContentFields,
+    EventTypes,
+    HistoryVisibility,
+    Membership,
+)
+from synapse.rest import admin
+from synapse.rest.client import login, media, room
+from synapse.server import HomeServer
+from synapse.types import JsonDict, UserID
+from synapse.util import Clock
+
+from tests import unittest
+from tests.server import FakeChannel
+from tests.test_utils import SMALL_PNG
+from tests.unittest import override_config
+
+
+class RestrictedResourceThumbnailTestCase(unittest.HomeserverTestCase):
+    """
+    Test the `/thumbnail` media endpoint for restricted media.
+
+    Something to note: rooms here will be set to room history visibility of 'joined'
+    at a minimum, or the media would be visible by default
+    """
+
+    servlets = [
+        media.register_servlets,
+        login.register_servlets,
+        admin.register_servlets,
+        room.register_servlets,
+    ]
+
+    def default_config(self) -> JsonDict:
+        config = super().default_config()
+        config.setdefault("experimental_features", {})
+        config["experimental_features"].update({"msc3911_enabled": True})
+        # This is what the defaults are for both 'crop' and 'scale' as reference
+        # We don't need to set these, but it's good to know
+        # "thumbnail_sizes": [
+        #     {"width": 32, "height": 32, "method": "crop"},
+        #     {"width": 240, "height": 320, "method": "scale"},
+        # ],
+        return config
+
+    def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
+        self.repo = hs.get_media_repository()
+        self.store = hs.get_datastores().main
+        self.creator = self.register_user("creator", "testpass")
+        self.creator_tok = self.login("creator", "testpass")
+        self.other_user = self.register_user("random_user", "testpass")
+        self.other_user_tok = self.login("random_user", "testpass")
+        self.other_profile_test_user = self.register_user(
+            "profile_test_user", "testpass"
+        )
+        self.other_profile_test_user_tok = self.login("profile_test_user", "testpass")
+
+    def create_resource_dict(self) -> dict[str, Resource]:
+        resources = super().create_resource_dict()
+        resources["/_matrix/media"] = self.hs.get_media_repository_resource()
+        return resources
+
+    def _create_restricted_media(self, user: str) -> MXCUri:
+        """
+        Insert our media directly into the database/repo. This creates the necessary
+        rows and sets the media as 'restricted' but does establish any attachments.
+        """
+        mxc_uri = self.get_success(
+            self.repo.create_or_update_content(
+                "image/png",
+                "test_png_upload",
+                io.BytesIO(SMALL_PNG),
+                67,
+                UserID.from_string(user),
+                restricted=True,
+            )
+        )
+        return mxc_uri
+
+    def fetch_thumbnail(
+        self,
+        mxc_uri: MXCUri,
+        method: str = "crop",
+        access_token: Optional[str] = None,
+        expect_code: int = 200,
+    ) -> FakeChannel:
+        """
+        Attempt media retrieval from the `/thumbnail` endpoint. Assert's expected code
+        before returning raw channel
+        """
+        params = "?width=1&height=1&method=" + method
+        channel = self.make_request(
+            "GET",
+            f"/_matrix/client/v1/media/thumbnail/{mxc_uri.server_name}/{mxc_uri.media_id}{params}",
+            access_token=access_token or self.creator_tok,
+        )
+        assert channel.code == expect_code, channel.code
+        return channel
+
+    def test_user_download_local_media_thumbnail_unrestricted(self) -> None:
+        """Test that unrestricted media is not affected"""
+        # Note that 'restricted' is marked as 'False' here
+        content_mxc_uri = self.get_success(
+            self.repo.create_or_update_content(
+                "image/png",
+                "test_png_upload",
+                io.BytesIO(SMALL_PNG),
+                67,
+                UserID.from_string(self.other_user),
+                restricted=False,
+            )
+        )
+        # The assertion of 200 as a response code is part of the function
+        self.fetch_thumbnail(content_mxc_uri)
+        self.fetch_thumbnail(content_mxc_uri, access_token=self.other_user_tok)
+
+    def test_download_local_media_restricted_but_pending_state(self) -> None:
+        """Test originating user can access media even though it is not attached"""
+        mxc_uri = self._create_restricted_media(self.creator)
+
+        # The creator user can see their own media
+        self.fetch_thumbnail(mxc_uri)
+        # But another user can not
+        self.fetch_thumbnail(mxc_uri, access_token=self.other_user_tok, expect_code=403)
+
+    def test_user_download_local_media_attached_to_user_profile_success(self) -> None:
+        """Test retrieving media attached to user's profile"""
+        prime_mxc_uri = self._create_restricted_media(self.creator)
+        other_mxc_uri = self._create_restricted_media(self.other_profile_test_user)
+        # Inject directly to the database, we are not here to test the profile endpoint
+        self.get_success(
+            self.store.set_media_restricted_to_user_profile(
+                prime_mxc_uri.server_name,
+                prime_mxc_uri.media_id,
+                self.creator,
+            )
+        )
+        self.get_success(
+            self.store.set_media_restricted_to_user_profile(
+                other_mxc_uri.server_name,
+                other_mxc_uri.media_id,
+                self.other_profile_test_user,
+            )
+        )
+
+        # Should be able to see their own
+        self.fetch_thumbnail(prime_mxc_uri, access_token=self.creator_tok)
+        self.fetch_thumbnail(
+            other_mxc_uri, access_token=self.other_profile_test_user_tok
+        )
+
+        # Should be able to see each others
+        self.fetch_thumbnail(other_mxc_uri, access_token=self.creator_tok)
+        self.fetch_thumbnail(
+            prime_mxc_uri, access_token=self.other_profile_test_user_tok
+        )
+
+    @override_config(
+        {
+            "limit_profile_requests_to_users_who_share_rooms": True,
+        }
+    )
+    def test_user_download_local_media_attached_to_user_profile_failure(self) -> None:
+        """
+        Test that limiting profile requests works as expected. Specifically, that users
+        that are not sharing a room can not see profile avatars
+        """
+
+        prime_mxc_uri = self._create_restricted_media(self.creator)
+        other_mxc_uri = self._create_restricted_media(self.other_profile_test_user)
+        # Inject directly to the database, we are not here to test the profile endpoint
+        self.get_success(
+            self.store.set_media_restricted_to_user_profile(
+                prime_mxc_uri.server_name,
+                prime_mxc_uri.media_id,
+                self.creator,
+            )
+        )
+        self.get_success(
+            self.store.set_media_restricted_to_user_profile(
+                other_mxc_uri.server_name,
+                other_mxc_uri.media_id,
+                self.other_profile_test_user,
+            )
+        )
+
+        # Should be able to see their own
+        self.fetch_thumbnail(prime_mxc_uri, access_token=self.creator_tok)
+        self.fetch_thumbnail(
+            other_mxc_uri, access_token=self.other_profile_test_user_tok
+        )
+
+        # Should NOT be able to see each others, since the limitation setting is enabled
+        self.fetch_thumbnail(
+            other_mxc_uri, access_token=self.creator_tok, expect_code=403
+        )
+        self.fetch_thumbnail(
+            prime_mxc_uri,
+            access_token=self.other_profile_test_user_tok,
+            expect_code=403,
+        )
+
+    def test_users_download_local_media_attached_to_message_event_success(self) -> None:
+        """Test that can local media attached to image event can be viewed"""
+        mxc_uri = self._create_restricted_media(self.creator)
+        room_id = self.helper.create_room_as(self.creator, tok=self.creator_tok)
+
+        # set room history_visibility to joined, otherwise it will be 'shared'
+        self.helper.send_state(
+            room_id=room_id,
+            event_type=EventTypes.RoomHistoryVisibility,
+            body={"history_visibility": HistoryVisibility.JOINED},
+            tok=self.creator_tok,
+        )
+
+        _ = self.helper.join(room_id, self.other_user, tok=self.other_user_tok)
+        # TODO: verify this file info is legit, because it does not match SMALL_PNG. It
+        #  seems to work tho, oddly
+        image = {
+            "body": "test_png_upload",
+            "info": {"h": 1, "mimetype": "image/png", "size": 67, "w": 1},
+            "msgtype": "m.image",
+            "url": str(mxc_uri),
+        }
+        json_body = self.helper.send_event(
+            room_id,
+            "m.room.message",
+            content=image,
+            tok=self.creator_tok,
+            expect_code=200,
+            attach_media_mxc=str(mxc_uri),
+        )
+        assert "event_id" in json_body
+
+        # Both users should be able to see the event
+        self.fetch_thumbnail(mxc_uri)
+        self.fetch_thumbnail(mxc_uri, access_token=self.other_user_tok)
+
+    def test_users_download_local_media_attached_to_message_event_failure(self) -> None:
+        """Test that can local media attached to image event can be restricted"""
+        mxc_uri = self._create_restricted_media(self.creator)
+        room_id = self.helper.create_room_as(self.creator, tok=self.creator_tok)
+
+        # set room history_visibility to joined
+        self.helper.send_state(
+            room_id=room_id,
+            event_type=EventTypes.RoomHistoryVisibility,
+            body={"history_visibility": HistoryVisibility.JOINED},
+            tok=self.creator_tok,
+        )
+
+        image = {
+            "body": "test_png_upload",
+            "info": {"h": 1, "mimetype": "image/png", "size": 67, "w": 1},
+            "msgtype": "m.image",
+            "url": str(mxc_uri),
+        }
+        json_body = self.helper.send_event(
+            room_id,
+            "m.room.message",
+            content=image,
+            tok=self.creator_tok,
+            expect_code=200,
+            attach_media_mxc=str(mxc_uri),
+        )
+        assert "event_id" in json_body
+
+        # Specifically, join the user AFTER sending the attaching message
+        self.helper.join(room_id, self.other_user, tok=self.other_user_tok)
+
+        self.fetch_thumbnail(mxc_uri)
+        # The other user was not in the room at the time the image was sent, so this
+        # should fail.
+        self.fetch_thumbnail(mxc_uri, access_token=self.other_user_tok, expect_code=403)
+
+    def test_user_download_local_media_attached_to_state_event_success(self) -> None:
+        """Test that a simple membership avatar is viewable when appropriate"""
+        mxc_uri = self._create_restricted_media(self.creator)
+        room_id = self.helper.create_room_as(self.creator, tok=self.creator_tok)
+
+        # set room history_visibility to joined
+        self.helper.send_state(
+            room_id=room_id,
+            event_type=EventTypes.RoomHistoryVisibility,
+            body={"history_visibility": HistoryVisibility.JOINED},
+            tok=self.creator_tok,
+        )
+
+        _ = self.helper.join(room_id, self.other_user, tok=self.other_user_tok)
+
+        membership_content = {
+            EventContentFields.MEMBERSHIP: Membership.JOIN,
+            "avatar_url": str(mxc_uri),
+        }
+        json_body = self.helper.send_state(
+            room_id,
+            EventTypes.Member,
+            body=membership_content,
+            tok=self.creator_tok,
+            expect_code=200,
+            state_key=self.creator,
+            attach_media_mxc=str(mxc_uri),
+        )
+        assert "event_id" in json_body
+
+        # Both users should be able to see the media
+        self.fetch_thumbnail(mxc_uri)
+        self.fetch_thumbnail(mxc_uri, access_token=self.other_user_tok)
+
+    def test_user_download_local_media_attached_to_state_event_failure(self) -> None:
+        """Test that a simple membership avatar is restricted when appropriate"""
+        mxc_uri = self._create_restricted_media(self.creator)
+        room_id = self.helper.create_room_as(self.creator, tok=self.creator_tok)
+        # set room history_visibility to joined
+        self.helper.send_state(
+            room_id=room_id,
+            event_type=EventTypes.RoomHistoryVisibility,
+            body={"history_visibility": HistoryVisibility.JOINED},
+            tok=self.creator_tok,
+        )
+
+        membership_content = {
+            EventContentFields.MEMBERSHIP: Membership.JOIN,
+            "avatar_url": str(mxc_uri),
+        }
+        json_body = self.helper.send_state(
+            room_id,
+            EventTypes.Member,
+            body=membership_content,
+            tok=self.creator_tok,
+            expect_code=200,
+            state_key=self.creator,
+            attach_media_mxc=str(mxc_uri),
+        )
+        assert "event_id" in json_body
+
+        _ = self.helper.join(room_id, self.other_user, tok=self.other_user_tok)
+
+        self.fetch_thumbnail(mxc_uri)
+        self.fetch_thumbnail(mxc_uri, access_token=self.other_user_tok, expect_code=403)


### PR DESCRIPTION
# Linked Media MSC3911 AP9: Media copy endpoint follow up [#3410](https://github.com/famedly/product-management/issues/3410)
fixes #3410

- [x] Media permissions should be checked when copying a piece of media. It should follow the same rules as when downloading media
- [x] it might not be necessary, but we should possibly also support the `timeout_ms` for async media support.