### PR TITLE
MSC3911 AP9: Media copy endpoint follow up

### DIFF
--- a/synapse/media/media_repository.py
+++ b/synapse/media/media_repository.py
@@ -458,6 +458,8 @@ class MediaRepository:
 
             # The file has been uploaded, so stop looping
             if media_info.media_length is not None:
+                if isinstance(request.requester, Requester):
+                    await self.is_media_visible(request.requester.user, media_info)
                 return media_info
 
             # Check if the media ID has expired and still hasn't been uploaded to.

--- a/synapse/storage/databases/main/media_repository.py
+++ b/synapse/storage/databases/main/media_repository.py
@@ -768,7 +768,8 @@ class MediaRepositoryStore(MediaRepositoryBackgroundUpdateStore):
         if row is None:
             return row
         restriction_info = None
-        if row[9] is not None and row[9] is True:
+
+        if row[9] is not None and row[9]:
             restriction_info = await self.get_media_restrictions(origin, media_id)
 
         return RemoteMedia(


### PR DESCRIPTION
# Linked Media MSC3911 AP9: Media copy endpoint follow up [#3410](https://github.com/famedly/product-management/issues/3410)
fixes #3410

- [x] Media permissions should be checked when copying a piece of media. It should follow the same rules as when downloading media
- [x] it might not be necessary, but we should possibly also support the `timeout_ms` for async media support.