### PR TITLE
MSC3911: AP6 automatic copy and attach during member event with worker-s…

### DIFF
--- a/tests/rest/client/test_media.py
+++ b/tests/rest/client/test_media.py
@@ -4646,6 +4646,9 @@ class RestrictedMediaBackwardCompatTestCase(unittest.HomeserverTestCase):
 
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         self.repo = hs.get_media_repository()
+        assert isinstance(self.repo, MediaRepository)
+        self.media_storage = self.repo.media_storage
+
         self.client = hs.get_federation_http_client()
         self.store = hs.get_datastores().main
         self.user = self.register_user("user", "pass")
@@ -4721,9 +4724,7 @@ class RestrictedMediaBackwardCompatTestCase(unittest.HomeserverTestCase):
         file_id = media_id
         file_info = FileInfo(None, file_id=file_id)
 
-        media_storage = self.hs.get_media_repository().media_storage
-
-        ctx = media_storage.store_into_file(file_info)
+        ctx = self.media_storage.store_into_file(file_info)
         (f, fname) = self.get_success(ctx.__aenter__())
         f.write(SMALL_PNG)
         self.get_success(ctx.__aexit__(None, None, None))
@@ -4784,9 +4785,7 @@ class RestrictedMediaBackwardCompatTestCase(unittest.HomeserverTestCase):
         file_id = media_id
         file_info = FileInfo(server_name=self.other_server_name, file_id=file_id)
 
-        media_storage = self.hs.get_media_repository().media_storage
-
-        ctx = media_storage.store_into_file(file_info)
+        ctx = self.media_storage.store_into_file(file_info)
         (f, fname) = self.get_success(ctx.__aenter__())
         f.write(SMALL_PNG)
         self.get_success(ctx.__aexit__(None, None, None))


### PR DESCRIPTION
# MSC3911 AP6: Automatically copy & attach media when updating member events [#3356](https://github.com/famedly/product-management/issues/3356)

There are several cases, where a member event might be updated:
- profile changes (i.e. global avatar change)
- join, knock, invite, kick, ban, unban
- creating a room
- upgrading a room

In those cases, if attached media is used, it needs to be copied and attached implicitly.
Currently we won't support a user passing a custom avatar in the endpoint, which technically does work in synapse, but is not part of the spec.

# Acceptance criteria

- [x] When a user implicitly creates a membership event, the media should be copied and attached automatically
- [x] This should have unit tests
