### PR TITLE
feat(MSC3911): Don't wait for the actual file copy to return a response

### DIFF
--- a/synapse/media/media_repository.py
+++ b/synapse/media/media_repository.py
@@ -852,18 +852,20 @@ class MediaRepository(AbstractMediaRepository):
         # class. It needs abstraction badly, but that is beyond me at the moment.
         io_object = open(local_path, "rb")
 
+        mxc_str, _ = await self.create_media_id(auth_user, restricted=True)
+        new_mxc_uri = MXCUri.from_str(mxc_str)
         # Let existing methods handle creating the new file for us. By not passing a
         # media id, one will be created.
-        new_mxc_uri = await self.create_or_update_content(
+        run_as_background_process(
+            "background_copy_media",
+            self.create_or_update_content,
             media_type=old_media_info.media_type,
             upload_name=old_media_info.upload_name,
             content=io_object,
             content_length=old_media_info.media_length,
             auth_user=auth_user,
-            restricted=True,
+            media_id=new_mxc_uri.media_id,
         )
-        # I could not find a place this was close()'d explicitly, but this felt prudent
-        io_object.close()
 
         return new_mxc_uri
 


### PR DESCRIPTION
Depending on the size of the file, it may take some time to make the filesystem level copy. There is nothing in that process that will be useful to return to the waiting user that they will not find out when the media 404's like it would anyway if the disk it's on died. Background that process