### PR TITLE
MSC3911: ap? automatic pending media deletion

### DIFF
--- a/docker/complement/conf/workers-shared-extra.yaml.j2
+++ b/docker/complement/conf/workers-shared-extra.yaml.j2
@@ -130,7 +130,11 @@ experimental_features:
   # Invite filtering
   msc4155_enabled: true
   # Media Attachment
-  msc3911_enabled: true
+  msc3911:
+    enabled: true
+    block_unrestricted_media_upload: false
+    purge_pending_unattached_media: true
+    pending_media_cleanup_interval_ms: 86400000 # 1 day
 
 server_notices:
   system_mxid_localpart: _server

--- a/synapse/config/experimental.py
+++ b/synapse/config/experimental.py
@@ -365,6 +365,22 @@ class MSC3866Config:
     require_approval_for_new_accounts: bool = False
 
 
+@attr.s(auto_attribs=True, frozen=True, slots=True)
+class MSC3911Config:
+    """Configuration for MSC3911 (Linking Media to Events)"""
+
+    # MSC3911 is enabled
+    enabled: bool = False
+
+    # Disable the current media create and upload endpoints
+    block_unrestricted_media_upload: bool = False
+
+    # Delete pending media that is older than certain interval and not attached to any events.
+    purge_pending_unattached_media: bool = False
+    # This configures how often the cleanup loop run in milliseconds
+    pending_media_cleanup_interval_ms: int = 24 * 60 * 60 * 1000  # 1 day
+
+
 class ExperimentalConfig(Config):
     """Config section for enabling experimental features"""
 
@@ -590,14 +606,5 @@ class ExperimentalConfig(Config):
         self.msc4306_enabled: bool = experimental.get("msc4306_enabled", False)
 
         # MSC3911: Linking Media to Events
-        self.msc3911_enabled: bool = experimental.get("msc3911_enabled", False)
-
-        # MSC3911: Disable the current media create and upload endpoints
-        self.msc3911_unrestricted_media_upload_disabled: bool = experimental.get(
-            "msc3911_unrestricted_media_upload_disabled", False
-        )
-
-        # MSC3911: Delete pending media that is older than 24 hours but not attached to any events
-        self.msc3911_enabled_media_retention = experimental.get(
-            "msc3911_enabled_media_retention", False
-        )
+        raw_msc3911_config = experimental.get("msc3911", {})
+        self.msc3911 = MSC3911Config(**raw_msc3911_config)

--- a/synapse/config/experimental.py
+++ b/synapse/config/experimental.py
@@ -592,7 +592,12 @@ class ExperimentalConfig(Config):
         # MSC3911: Linking Media to Events
         self.msc3911_enabled: bool = experimental.get("msc3911_enabled", False)
 
-        # Disable the current media create and upload endpoints
+        # MSC3911: Disable the current media create and upload endpoints
         self.msc3911_unrestricted_media_upload_disabled: bool = experimental.get(
             "msc3911_unrestricted_media_upload_disabled", False
+        )
+
+        # MSC3911: Delete pending media that is older than 24 hours but not attached to any events
+        self.msc3911_enabled_media_retention = experimental.get(
+            "msc3911_enabled_media_retention", False
         )

--- a/synapse/federation/transport/server/federation.py
+++ b/synapse/federation/transport/server/federation.py
@@ -79,7 +79,7 @@ class BaseFederationServerServlet(BaseFederationServlet):
     ):
         super().__init__(hs, authenticator, ratelimiter, server_name)
         self.handler = hs.get_federation_server()
-        self.enable_restricted_media = hs.config.experimental.msc3911_enabled
+        self.enable_restricted_media = hs.config.experimental.msc3911.enabled
 
 
 class FederationSendServlet(BaseFederationServerServlet):

--- a/synapse/handlers/profile.py
+++ b/synapse/handlers/profile.py
@@ -80,9 +80,9 @@ class ProfileHandler:
 
         self._third_party_rules = hs.get_module_api_callbacks().third_party_event_rules
 
-        self.enable_restricted_media = hs.config.experimental.msc3911_enabled
-        self.disable_unrestricted_media = (
-            hs.config.experimental.msc3911_unrestricted_media_upload_disabled
+        self.enable_restricted_media = hs.config.experimental.msc3911.enabled
+        self.block_unrestricted_media = (
+            hs.config.experimental.msc3911.block_unrestricted_media_upload
         )
 
     async def get_profile(self, user_id: str, ignore_backoff: bool = True) -> JsonDict:
@@ -334,7 +334,7 @@ class ProfileHandler:
             # event, it will either be copied/passed along/dropped depending on the
             # above circumstances
             if not media_info:
-                if self.disable_unrestricted_media:
+                if self.block_unrestricted_media:
                     # The user should have done a COPY on this media previous to this
                     # attempt to set
                     raise SynapseError(
@@ -345,7 +345,7 @@ class ProfileHandler:
                 # For backwards compatible behavior, treat the media as unrestricted
                 return
 
-        if self.disable_unrestricted_media and not media_info.restricted:
+        if self.block_unrestricted_media and not media_info.restricted:
             raise SynapseError(
                 HTTPStatus.BAD_REQUEST,
                 f"The media attachment request is invalid as the media '{mxc_uri.media_id}' is not restricted",

--- a/synapse/handlers/room.py
+++ b/synapse/handlers/room.py
@@ -1232,7 +1232,7 @@ class RoomCreationHandler:
         room_avatar = initial_state.get((EventTypes.RoomAvatar, ""))
         # It is unfortunate that this conditional block has to be run twice: once here
         # to validate the data and again to actually attach the media reference.
-        if room_avatar is not None and self.config.experimental.msc3911_enabled:
+        if room_avatar is not None and self.config.experimental.msc3911.enabled:
             # this should be an mxc, but the spec does not specifically say it has to be
             extracted_media_id: Optional[str] = room_avatar.get("url")
             # It may be that "url" is set to either an empty string or None. Accept
@@ -1550,7 +1550,7 @@ class RoomCreationHandler:
 
             mxc_restrictions = None
             if (
-                self.config.experimental.msc3911_enabled
+                self.config.experimental.msc3911.enabled
                 and etype == EventTypes.RoomAvatar
             ):
                 # this should be an mxc, but the spec does not specifically say it has to be

--- a/synapse/handlers/room_member.py
+++ b/synapse/handlers/room_member.py
@@ -109,9 +109,9 @@ class RoomMemberHandler(metaclass=abc.ABCMeta):
         self.account_data_handler = hs.get_account_data_handler()
         self.event_auth_handler = hs.get_event_auth_handler()
         self._worker_lock_handler = hs.get_worker_locks_handler()
-        self.enable_restricted_media = hs.config.experimental.msc3911_enabled
+        self.enable_restricted_media = hs.config.experimental.msc3911.enabled
         self.allow_legacy_media = (
-            not hs.config.experimental.msc3911_unrestricted_media_upload_disabled
+            not hs.config.experimental.msc3911.block_unrestricted_media_upload
         )
 
         self._membership_types_to_include_profile_data_in = {

--- a/synapse/media/thumbnailer.py
+++ b/synapse/media/thumbnailer.py
@@ -271,7 +271,7 @@ class ThumbnailProvider:
         self.media_storage = media_storage
         self.store = hs.get_datastores().main
         self.dynamic_thumbnails = hs.config.media.dynamic_thumbnails
-        self.enable_media_restriction = self.hs.config.experimental.msc3911_enabled
+        self.enable_media_restriction = self.hs.config.experimental.msc3911.enabled
 
     async def respond_local_thumbnail(
         self,

--- a/synapse/rest/client/media.py
+++ b/synapse/rest/client/media.py
@@ -410,7 +410,7 @@ def register_servlets(hs: "HomeServer", http_server: HttpServer) -> None:
     MediaConfigResource(hs).register(http_server)
     ThumbnailResource(hs, media_repo, media_repo.media_storage).register(http_server)
     DownloadResource(hs, media_repo).register(http_server)
-    if hs.config.experimental.msc3911_enabled:
+    if hs.config.experimental.msc3911.enabled:
         CreateResource(hs, media_repo, restricted=True).register(http_server)
         UploadRestrictedResource(hs, media_repo).register(http_server)
         CopyResource(hs, media_repo).register(http_server)

--- a/synapse/rest/client/profile.py
+++ b/synapse/rest/client/profile.py
@@ -109,7 +109,7 @@ class ProfileFieldRestServlet(RestServlet):
         self.hs = hs
         self.profile_handler = hs.get_profile_handler()
         self.auth = hs.get_auth()
-        self.enable_restricted_media = hs.config.experimental.msc3911_enabled
+        self.enable_restricted_media = hs.config.experimental.msc3911.enabled
 
     async def on_GET(
         self, request: SynapseRequest, user_id: str, field_name: str
@@ -178,7 +178,7 @@ class ProfileFieldRestServlet(RestServlet):
 
         content = parse_json_object_from_request(request)
         try:
-            new_value = content[field_name]
+            input_value = content[field_name]
         except KeyError:
             raise SynapseError(
                 400, f"Missing key '{field_name}'", errcode=Codes.MISSING_PARAM
@@ -200,24 +200,24 @@ class ProfileFieldRestServlet(RestServlet):
             )
         if field_name == ProfileFields.DISPLAYNAME:
             await self.profile_handler.set_displayname(
-                user, requester, new_value, is_admin, propagate=propagate
+                user, requester, input_value, is_admin, propagate=propagate
             )
         elif field_name == ProfileFields.AVATAR_URL:
-            if self.enable_restricted_media and new_value:
+            if self.enable_restricted_media and input_value:
                 current_avatar_url = (
                     await self.profile_handler.store.get_profile_avatar_url(
                         requester.user
                     )
                 )
                 # If new_value is the same as existing one, keep the function idempotent
-                if current_avatar_url and str(current_avatar_url) == new_value:
+                if current_avatar_url and str(current_avatar_url) == input_value:
                     return 200, {}
             await self.profile_handler.set_avatar_url(
-                user, requester, new_value, is_admin, propagate=propagate
+                user, requester, input_value, is_admin, propagate=propagate
             )
         else:
             await self.profile_handler.set_profile_field(
-                user, requester, field_name, new_value, is_admin
+                user, requester, field_name, input_value, is_admin
             )
 
         return 200, {}

--- a/synapse/rest/client/room.py
+++ b/synapse/rest/client/room.py
@@ -277,7 +277,7 @@ class RoomStateEventRestServlet(RestServlet):
         self._max_event_delay_ms = hs.config.server.max_event_delay_ms
         self._spam_checker_module_callbacks = hs.get_module_api_callbacks().spam_checker
         self.store = hs.get_datastores().main
-        self.enable_restricted_media = hs.config.experimental.msc3911_enabled
+        self.enable_restricted_media = hs.config.experimental.msc3911.enabled
         self.server_name = hs.config.server.server_name
 
     def register(self, http_server: HttpServer) -> None:
@@ -486,7 +486,7 @@ class RoomSendEventRestServlet(TransactionRestServlet):
         self.auth = hs.get_auth()
         self._max_event_delay_ms = hs.config.server.max_event_delay_ms
         self.store = hs.get_datastores().main
-        self.enable_restricted_media = hs.config.experimental.msc3911_enabled
+        self.enable_restricted_media = hs.config.experimental.msc3911.enabled
         self.server_name = hs.config.server.server_name
 
     def register(self, http_server: HttpServer) -> None:

--- a/synapse/rest/client/versions.py
+++ b/synapse/rest/client/versions.py
@@ -178,9 +178,9 @@ class VersionsRestServlet(RestServlet):
                     # MSC4155: Invite filtering
                     "org.matrix.msc4155": self.config.experimental.msc4155_enabled,
                     # MSC3911: Linking Media to Events
-                    "org.matrix.msc3911": self.config.experimental.msc3911_enabled,
+                    "org.matrix.msc3911": self.config.experimental.msc3911.enabled,
                     # MSC3911: Unrestricted Media Upload
-                    "org.matrix.msc3911.unrestricted_media_upload_disabled": self.config.experimental.msc3911_unrestricted_media_upload_disabled,
+                    "org.matrix.msc3911.block_unrestricted_media_upload": self.config.experimental.msc3911.block_unrestricted_media_upload,
                 },
             },
         )

--- a/synapse/rest/media/create_resource.py
+++ b/synapse/rest/media/create_resource.py
@@ -57,8 +57,8 @@ class CreateResource(RestServlet):
             cfg=hs.config.ratelimiting.rc_media_create,
         )
         # MSC3911: If this is enabled, this endpoint will not allow media creation,which is unrestricted.
-        self.msc3911_unrestricted_media_upload_disabled = (
-            hs.config.experimental.msc3911_unrestricted_media_upload_disabled
+        self.msc3911_block_unrestricted_media_upload = (
+            hs.config.experimental.msc3911.block_unrestricted_media_upload
         )
         self.restricted = restricted
 
@@ -70,7 +70,7 @@ class CreateResource(RestServlet):
             self.PATTERNS = [re.compile("/_matrix/media/v1/create")]
 
     async def on_POST(self, request: SynapseRequest) -> None:
-        if not self.restricted and self.msc3911_unrestricted_media_upload_disabled:
+        if not self.restricted and self.msc3911_block_unrestricted_media_upload:
             raise SynapseError(
                 403,
                 "Unrestricted media creation is disabled",

--- a/synapse/rest/media/upload_resource.py
+++ b/synapse/rest/media/upload_resource.py
@@ -53,9 +53,8 @@ class BaseUploadServlet(RestServlet):
         self._media_repository_callbacks = (
             hs.get_module_api_callbacks().media_repository
         )
-        # MSC3911: If this is enabled, this endpoint will not allow unrestricted media uploads.
-        self.msc3911_unrestricted_media_upload_disabled = (
-            hs.config.experimental.msc3911_unrestricted_media_upload_disabled
+        self.msc3911_block_unrestricted_media_upload = (
+            hs.config.experimental.msc3911.block_unrestricted_media_upload
         )
 
     async def _get_file_metadata(
@@ -117,7 +116,7 @@ class UploadServlet(BaseUploadServlet):
     PATTERNS = [re.compile("/_matrix/media/(r0|v3|v1)/upload$")]
 
     async def on_POST(self, request: SynapseRequest) -> None:
-        if self.msc3911_unrestricted_media_upload_disabled:
+        if self.msc3911_block_unrestricted_media_upload:
             raise SynapseError(
                 403,
                 "Unrestricted media upload is disabled",

--- a/synapse/storage/databases/main/media_repository.py
+++ b/synapse/storage/databases/main/media_repository.py
@@ -638,6 +638,29 @@ class MediaRepositoryStore(MediaRepositoryBackgroundUpdateStore):
             "get_pending_media", get_pending_media_txn
         )
 
+    async def get_pending_media_ids(self) -> list[str]:
+        """
+        Get a list of ids of pending media that is older than 24 hours and unattached.
+        """
+        threshold_ts = self._clock.time_msec() - 24 * 60 * 60 * 1000
+
+        def _get_pending_media_ids_txn(txn: LoggingTransaction) -> list[str]:
+            sql = """
+                SELECT local_media_repository.media_id
+                FROM local_media_repository
+                    LEFT JOIN media_attachments
+                    ON local_media_repository.media_id = media_attachments.media_id
+                WHERE local_media_repository.restricted IS TRUE
+                    AND media_attachments.restrictions_json IS NULL
+                    AND local_media_repository.created_ts < ?;
+            """
+            txn.execute(sql, (threshold_ts,))
+            return [row[0] for row in txn]
+
+        return await self.db_pool.runInteraction(
+            "get_pending_media_ids", _get_pending_media_ids_txn
+        )
+
     async def get_url_cache(self, url: str, ts: int) -> Optional[UrlCache]:
         """Get the media_id and ts for a cached URL as of the given timestamp
         Returns:

--- a/synapse/storage/databases/main/media_repository.py
+++ b/synapse/storage/databases/main/media_repository.py
@@ -638,11 +638,12 @@ class MediaRepositoryStore(MediaRepositoryBackgroundUpdateStore):
             "get_pending_media", get_pending_media_txn
         )
 
-    async def get_pending_media_ids(self) -> list[str]:
+    async def get_pending_media_ids(self, interval: int) -> list[str]:
         """
-        Get a list of ids of pending media that is older than 24 hours and unattached.
+        Get a list of ids of pending media that is older than the given interval and
+        unattached.
         """
-        threshold_ts = self._clock.time_msec() - 24 * 60 * 60 * 1000
+        threshold_ts = self._clock.time_msec() - interval
 
         def _get_pending_media_ids_txn(txn: LoggingTransaction) -> list[str]:
             sql = """

--- a/tests/federation/test_federation_media.py
+++ b/tests/federation/test_federation_media.py
@@ -232,7 +232,7 @@ class FederationRestrictedMediaDownloadsTest(unittest.FederatingHomeserverTestCa
     def default_config(self) -> JsonDict:
         config = super().default_config()
         config.setdefault("experimental_features", {})
-        config["experimental_features"].update({"msc3911_enabled": True})
+        config["experimental_features"].update({"msc3911": {"enabled": True}})
         return config
 
     def test_restricted_media_download_with_restrictions_field(self) -> None:
@@ -505,7 +505,7 @@ class FederationRestrictedThumbnailTest(unittest.FederatingHomeserverTestCase):
     def default_config(self) -> JsonDict:
         config = super().default_config()
         config.setdefault("experimental_features", {})
-        config["experimental_features"].update({"msc3911_enabled": True})
+        config["experimental_features"].update({"msc3911": {"enabled": True}})
         return config
 
     def test_restricted_thumbnail_download_with_restrictions_field(self) -> None:

--- a/tests/media/test_pending_media_deletion.py
+++ b/tests/media/test_pending_media_deletion.py
@@ -1,0 +1,239 @@
+import os
+from http import HTTPStatus
+
+from twisted.test.proto_helpers import MemoryReactor
+from twisted.web.resource import Resource
+
+from synapse.media.filepath import MediaFilePaths
+from synapse.media.media_repository import MediaRepository
+from synapse.rest import admin
+from synapse.rest.client import login, media, profile, room
+from synapse.server import HomeServer
+from synapse.types import UserID
+from synapse.util import Clock
+from synapse.util.stringutils import (
+    random_string,
+)
+
+from tests import unittest
+
+
+class PendingMediaDeletionTestCase(unittest.HomeserverTestCase):
+    servlets = [
+        media.register_servlets,
+        login.register_servlets,
+        admin.register_servlets,
+        room.register_servlets,
+        profile.register_servlets,
+    ]
+
+    def make_homeserver(self, reactor: MemoryReactor, clock: Clock) -> HomeServer:
+        config = self.default_config()
+        config.update(
+            {
+                "experimental_features": {
+                    "msc3911_enabled": True,
+                    "msc3911_enabled_media_retention": True,
+                },
+            }
+        )
+        return self.setup_test_homeserver(config=config)
+
+    def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
+        self.media_repository = hs.get_media_repository()
+        self.store = hs.get_datastores().main
+
+        self.user = self.register_user("user", "testpass")
+        self.tok = self.login("user", "testpass")
+
+        self.filepaths = MediaFilePaths(hs.config.media.media_store_path)
+
+    def create_resource_dict(self) -> dict[str, Resource]:
+        resources = super().create_resource_dict()
+        resources["/_matrix/media"] = self.hs.get_media_repository_resource()
+        return resources
+
+    def test_pending_media_deletion_success(self) -> None:
+        """
+        Test that media that is older than 24 hours yet not attached to any event or profile is deleted.
+        """
+        assert isinstance(self.media_repository, MediaRepository)
+
+        # Create 2 media that is restricted but not attached to any event or profile
+        random_content = bytes(random_string(24), "utf-8")
+        channel = self.make_request(
+            "POST",
+            "_matrix/client/unstable/org.matrix.msc3911/media/upload?filename=test_1",
+            random_content,
+            self.tok,
+            shorthand=False,
+            content_type=b"image/png",
+            custom_headers=[("Content-Length", str(24))],
+        )
+        assert channel.code == 200, channel.json_body
+        mxc_uri_str = channel.json_body.get("content_uri")
+        assert mxc_uri_str is not None
+        media_1_id = mxc_uri_str.rsplit("/", 1)[-1]
+
+        random_content = bytes(random_string(24), "utf-8")
+        channel = self.make_request(
+            "POST",
+            "_matrix/client/unstable/org.matrix.msc3911/media/upload?filename=test_2",
+            random_content,
+            self.tok,
+            shorthand=False,
+            content_type=b"image/png",
+            custom_headers=[("Content-Length", str(24))],
+        )
+        assert channel.code == 200, channel.json_body
+        mxc_uri_str = channel.json_body.get("content_uri")
+        assert mxc_uri_str is not None
+        media_2_id = mxc_uri_str.rsplit("/", 1)[-1]
+
+        # Prove that the media are written on the local media table
+        uploaded_media = self.get_success(
+            self.media_repository.store.get_local_media(media_1_id)
+        )
+        assert uploaded_media is not None
+        assert uploaded_media.attachments is None
+
+        uploaded_media = self.get_success(
+            self.media_repository.store.get_local_media(media_2_id)
+        )
+        assert uploaded_media is not None
+        assert uploaded_media.attachments is None
+
+        # Check if the file exists
+        local_path_1 = self.filepaths.local_media_filepath(media_1_id)
+        assert os.path.exists(local_path_1)
+        local_path_2 = self.filepaths.local_media_filepath(media_2_id)
+        assert os.path.exists(local_path_2)
+
+        # Advance 25 hours to make the media eligible for deletion
+        self.reactor.advance(25 * 60 * 60)
+
+        # Check the deletion is completed
+        uploaded_media = self.get_success(
+            self.media_repository.store.get_local_media(media_1_id)
+        )
+        assert uploaded_media is None
+
+        uploaded_media = self.get_success(
+            self.media_repository.store.get_local_media(media_2_id)
+        )
+        assert uploaded_media is None
+
+        # Attempt to access media to check if media is deleted from file
+        server_name = self.hs.hostname
+        channel = self.make_request(
+            "GET",
+            f"/_matrix/media/v3/download/{server_name}/{media_1_id}",
+            shorthand=False,
+            access_token=self.tok,
+        )
+        assert channel.code == 404, (
+            "Expected to receive a 404 on accessing deleted media: %s:%s"
+            % (server_name, media_1_id)
+        )
+
+        channel = self.make_request(
+            "GET",
+            f"/_matrix/media/v3/download/{server_name}/{media_2_id}",
+            shorthand=False,
+            access_token=self.tok,
+        )
+        assert channel.code == 404, (
+            "Expected to receive a 404 on accessing deleted media: %s:%s"
+            % (server_name, media_1_id)
+        )
+
+        # Test if the file is deleted
+        assert os.path.exists(local_path_1) is False
+        assert os.path.exists(local_path_2) is False
+
+    def test_pending_media_deletion_not_deleted_if_attached(self) -> None:
+        """
+        Test that media that is attached to an event or profile is not deleted.
+        """
+        assert isinstance(self.media_repository, MediaRepository)
+
+        # Create media via upload endpoint
+        random_content = bytes(random_string(24), "utf-8")
+        channel = self.make_request(
+            "POST",
+            "_matrix/client/unstable/org.matrix.msc3911/media/upload?filename=test_png_upload",
+            random_content,
+            self.tok,
+            shorthand=False,
+            content_type=b"image/png",
+            custom_headers=[("Content-Length", str(24))],
+        )
+        assert channel.code == 200, channel.json_body
+        mxc_uri_str = channel.json_body.get("content_uri")
+        assert mxc_uri_str is not None
+
+        # Attach the media to a profile
+        channel = self.make_request(
+            "PUT",
+            f"/_matrix/client/v3/profile/{self.user}/avatar_url",
+            access_token=self.tok,
+            content={"avatar_url": mxc_uri_str},
+        )
+        assert channel.code == HTTPStatus.OK
+        assert channel.json_body == {}
+        _, media_id = mxc_uri_str.rsplit("/", maxsplit=1)
+
+        # Check if media is updated with restrictions field
+        restrictions = self.get_success(
+            self.store.get_media_restrictions(self.hs.hostname, media_id)
+        )
+        assert restrictions is not None, str(restrictions)
+        assert restrictions.event_id is None
+        assert restrictions.profile_user_id == UserID.from_string(self.user)
+
+        # Advance 25 hours
+        self.reactor.advance(25 * 60 * 60)
+
+        # Check that media is not deleted
+        uploaded_media = self.get_success(
+            self.media_repository.store.get_local_media(media_id)
+        )
+        assert uploaded_media is not None
+
+    def test_pending_media_deletion_does_not_delete_unrestricted_media(self) -> None:
+        """
+        Test that unrestricted media should not be deleted.
+        """
+        assert isinstance(self.media_repository, MediaRepository)
+
+        # Create unrestricted media via upload endpoint
+        random_content = bytes(random_string(24), "utf-8")
+        channel = self.make_request(
+            "POST",
+            "_matrix/media/v3/upload?filename=unrestricted",
+            random_content,
+            self.tok,
+            shorthand=False,
+            content_type=b"image/png",
+            custom_headers=[("Content-Length", str(24))],
+        )
+        assert channel.code == 200, channel.json_body
+        mxc_uri_str = channel.json_body.get("content_uri")
+        assert mxc_uri_str is not None
+        _, media_id = mxc_uri_str.rsplit("/", maxsplit=1)
+
+        # Check if media is not restricted
+        media_info = self.get_success(
+            self.media_repository.store.get_local_media(media_id)
+        )
+        assert media_info is not None
+        assert media_info.restricted is False
+
+        # Advance 25 hours
+        self.reactor.advance(25 * 60 * 60)
+
+        # Check that media is not deleted
+        uploaded_media = self.get_success(
+            self.media_repository.store.get_local_media(media_id)
+        )
+        assert uploaded_media is not None

--- a/tests/replication/test_multi_media_repo.py
+++ b/tests/replication/test_multi_media_repo.py
@@ -502,7 +502,7 @@ class AuthenticatedMediaRepoShardTestCase(BaseMultiWorkerStreamTestCase):
 
 class CopyRestrictedResourceReplicationTestCase(BaseMultiWorkerStreamTestCase):
     """
-    Tests copy API when `msc3911_enabled` is configured to be True.
+    Tests copy API when `msc3911.enabled` is configured to be True.
     """
 
     servlets = [
@@ -515,7 +515,7 @@ class CopyRestrictedResourceReplicationTestCase(BaseMultiWorkerStreamTestCase):
         config = super().default_config()
         config.update(
             {
-                "experimental_features": {"msc3911_enabled": True},
+                "experimental_features": {"msc3911": {"enabled": True}},
                 "media_repo_instances": ["media_worker_1"],
             }
         )

--- a/tests/rest/client/test_media_download.py
+++ b/tests/rest/client/test_media_download.py
@@ -58,7 +58,7 @@ class RestrictedResourceDownloadTestCase(unittest.HomeserverTestCase):
     def default_config(self) -> JsonDict:
         config = super().default_config()
         config.setdefault("experimental_features", {})
-        config["experimental_features"].update({"msc3911_enabled": True})
+        config["experimental_features"].update({"msc3911": {"enabled": True}})
         return config
 
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:

--- a/tests/rest/client/test_media_thumbnail.py
+++ b/tests/rest/client/test_media_thumbnail.py
@@ -59,7 +59,7 @@ class RestrictedResourceThumbnailTestCase(unittest.HomeserverTestCase):
     def default_config(self) -> JsonDict:
         config = super().default_config()
         config.setdefault("experimental_features", {})
-        config["experimental_features"].update({"msc3911_enabled": True})
+        config["experimental_features"].update({"msc3911": {"enabled": True}})
         # This is what the defaults are for both 'crop' and 'scale' as reference
         # We don't need to set these, but it's good to know
         # "thumbnail_sizes": [

--- a/tests/rest/client/test_profile.py
+++ b/tests/rest/client/test_profile.py
@@ -45,7 +45,6 @@ from tests import unittest
 from tests.replication._base import BaseMultiWorkerStreamTestCase
 from tests.server import FakeChannel, make_request
 from tests.test_utils import SMALL_PNG
-from tests.unittest import override_config
 from tests.utils import USE_POSTGRES_FOR_TESTS
 
 
@@ -945,7 +944,7 @@ class ProfileMediaAttachmentTestCase(unittest.HomeserverTestCase):
     def default_config(self) -> JsonDict:
         config = super().default_config()
         config.setdefault("experimental_features", {})
-        config["experimental_features"].update({"msc3911_enabled": True})
+        config["experimental_features"].update({"msc3911": {"enabled": True}})
         return config
 
     def create_resource_dict(self) -> dict[str, Resource]:
@@ -1048,26 +1047,6 @@ class ProfileMediaAttachmentTestCase(unittest.HomeserverTestCase):
 
         assert channel.code == HTTPStatus.OK, channel.json_body
 
-    @override_config(
-        {"experimental_features": {"msc3911_unrestricted_media_upload_disabled": True}}
-    )
-    def test_attaching_unreachable_remote_media_to_profile_fails(self) -> None:
-        """
-        Test that media that can not be retrieved will fail to be attached to a user
-        profile when legacy unrestricted media is disabled.
-        """
-        # Generate non-existing media.
-        nonexistent_mxc_uri = MXCUri.from_str("mxc://remote/fakeMediaId_2")
-        channel = self.make_request(
-            "PUT",
-            f"/_matrix/client/v3/profile/{self.user}/avatar_url",
-            access_token=self.tok,
-            content={"avatar_url": str(nonexistent_mxc_uri)},
-        )
-
-        assert channel.code == HTTPStatus.NOT_FOUND, channel.json_body
-        assert channel.json_body["errcode"] == Codes.NOT_FOUND
-
     def test_attaching_unrestricted_media_to_profile(self) -> None:
         """
         Test that attaching unrestricted media to user profile also works
@@ -1097,43 +1076,6 @@ class ProfileMediaAttachmentTestCase(unittest.HomeserverTestCase):
             content={"avatar_url": str(content_uri)},
         )
         assert channel.code == 200, channel.result
-
-    @override_config(
-        {"experimental_features": {"msc3911_unrestricted_media_upload_disabled": True}}
-    )
-    def test_attaching_unrestricted_media_to_profile_fails(self) -> None:
-        """
-        Test that attaching unrestricted media to user profile fails when unrestricted
-        media is banned by configuration.
-        """
-        # Create unrestricted media.
-        content = io.BytesIO(SMALL_PNG)
-        content_uri = self.get_success(
-            self.media_repo.create_or_update_content(
-                "image/png",
-                "test_png_upload",
-                content,
-                67,
-                UserID.from_string(self.user),
-                restricted=False,
-            )
-        )
-
-        # Check media is unrestricted.
-        media_info = self.get_success(self.store.get_local_media(content_uri.media_id))
-        assert media_info is not None
-        assert not media_info.restricted
-
-        # Try to update user profile with unrestricted media.
-        channel = self.make_request(
-            "PUT",
-            f"/_matrix/client/v3/profile/{self.user}/avatar_url",
-            access_token=self.tok,
-            content={"avatar_url": str(content_uri)},
-        )
-        assert channel.code == HTTPStatus.BAD_REQUEST, channel.json_body
-        assert channel.json_body["errcode"] == Codes.INVALID_PARAM
-        assert "is not restricted" in channel.json_body["error"]
 
     def test_attaching_already_attached_media_to_profile_fails(self) -> None:
         """
@@ -1327,7 +1269,9 @@ class ProfileMediaAttachmentReplicationTestCase(BaseMultiWorkerStreamTestCase):
     def default_config(self) -> JsonDict:
         config = super().default_config()
         config.setdefault("experimental_features", {})
-        config["experimental_features"].update({"msc3911_enabled": True})
+        config["experimental_features"].update({"msc3911": {"enabled": True}})
+        # config["media_repo_instances"] = [MAIN_PROCESS_INSTANCE_NAME]
+
         return config
 
     def create_media_and_set_restricted_flag(self, user_id: str) -> MXCUri:


### PR DESCRIPTION
# Linked Media MSC3911 AP?: Automatic media deletion [#3365](https://github.com/famedly/product-management/issues/3365)

Background job to automatically delete unattached media. This should likely use the same 24h as asynchronous media uploads.

# Acceptance criteria

- [x] Background job to delete pending media after 24h
