### PR TITLE
fix(MSC3911): Correct where to find remote media at on the local filesystem when doing a copy

### DIFF
--- a/synapse/media/media_repository.py
+++ b/synapse/media/media_repository.py
@@ -869,7 +869,8 @@ class MediaRepository(AbstractMediaRepository):
         old_media_info = await self.get_media_info(existing_mxc)
         if isinstance(old_media_info, RemoteMedia):
             file_info = FileInfo(
-                server_name=old_media_info.media_origin, file_id=old_media_info.media_id
+                server_name=old_media_info.media_origin,
+                file_id=old_media_info.filesystem_id,
             )
         else:
             file_info = FileInfo(server_name=None, file_id=old_media_info.media_id)


### PR DESCRIPTION
Remote media is saved with a different filename after it has been downloaded from a remote server and that filename has nothing to do with the `media_id`. Fix that by using the `RemoteMedia.filesystem_id` field instead of the `media_id` field as is used for `LocalMedia`