### PR TITLE
feat: add message and event count metric

### DIFF
--- a/synapse/metrics/common_usage_metrics.py
+++ b/synapse/metrics/common_usage_metrics.py
@@ -37,12 +37,35 @@ current_dau_gauge = Gauge(
     labelnames=[SERVER_NAME_LABEL],
 )
 
+# Gauges for message & event counts
+messages_by_source_gauge = Gauge(
+    "synapse_messages_by_source",
+    "Number of messages sent by the server, both local and remote events.",
+    ["source", SERVER_NAME_LABEL],
+)
+events_by_source_gauge = Gauge(
+    "synapse_events_by_source",
+    "Number of events sent by the server, grouped by source",
+    ["source", SERVER_NAME_LABEL],
+)
+encrypted_events_by_source_gauge = Gauge(
+    "synapse_encrypted_events_by_source",
+    "Number of encrypted events sent by the server, grouped by source",
+    ["source", SERVER_NAME_LABEL],
+)
+
 
 @attr.s(auto_attribs=True)
 class CommonUsageMetrics:
     """Usage metrics shared between the phone home stats and the prometheus exporter."""
 
     daily_active_users: int
+    message_by_local: int
+    message_by_remote: int
+    event_by_local: int
+    event_by_remote: int
+    encrypted_event_by_local: int
+    encrypted_event_by_remote: int
 
 
 class CommonUsageMetricsManager:
@@ -82,9 +105,23 @@ class CommonUsageMetricsManager:
         use if it doesn't exist yet, or update it.
         """
         dau_count = await self._store.count_daily_users()
+        (
+            local_message_count,
+            remote_message_count,
+            local_event_count,
+            remote_event_count,
+            local_encrypted_count,
+            remote_encrypted_count,
+        ) = await self._store.get_event_counts_for_metrics()
 
         return CommonUsageMetrics(
             daily_active_users=dau_count,
+            message_by_local=local_message_count,
+            message_by_remote=remote_message_count,
+            event_by_local=local_event_count,
+            event_by_remote=remote_event_count,
+            encrypted_event_by_local=local_encrypted_count,
+            encrypted_event_by_remote=remote_encrypted_count,
         )
 
     async def _update_gauges(self) -> None:
@@ -94,3 +131,21 @@ class CommonUsageMetricsManager:
         current_dau_gauge.labels(
             **{SERVER_NAME_LABEL: self.server_name},
         ).set(float(metrics.daily_active_users))
+        messages_by_source_gauge.labels(
+            source="local", **{SERVER_NAME_LABEL: self.server_name}
+        ).set(float(metrics.message_by_local))
+        messages_by_source_gauge.labels(
+            source="remote", **{SERVER_NAME_LABEL: self.server_name}
+        ).set(float(metrics.message_by_remote))
+        events_by_source_gauge.labels(
+            source="local", **{SERVER_NAME_LABEL: self.server_name}
+        ).set(float(metrics.event_by_local))
+        events_by_source_gauge.labels(
+            source="remote", **{SERVER_NAME_LABEL: self.server_name}
+        ).set(float(metrics.event_by_remote))
+        encrypted_events_by_source_gauge.labels(
+            source="local", **{SERVER_NAME_LABEL: self.server_name}
+        ).set(float(metrics.encrypted_event_by_local))
+        encrypted_events_by_source_gauge.labels(
+            source="remote", **{SERVER_NAME_LABEL: self.server_name}
+        ).set(float(metrics.encrypted_event_by_remote))

--- a/tests/metrics/test_common_usage_metrics.py
+++ b/tests/metrics/test_common_usage_metrics.py
@@ -1,0 +1,208 @@
+from twisted.test.proto_helpers import MemoryReactor
+
+from synapse.metrics.common_usage_metrics import CommonUsageMetrics
+from synapse.rest import admin, login, register, room
+from synapse.server import HomeServer
+from synapse.util import Clock
+
+from tests.test_utils import event_injection
+from tests.unittest import FederatingHomeserverTestCase
+
+
+class CommonUsageMetricsManagerTestCase(FederatingHomeserverTestCase):
+    """
+    Tests for the CommonUsageMetricsManager.
+    """
+
+    servlets = [
+        admin.register_servlets_for_client_rest_resource,
+        room.register_servlets,
+        register.register_servlets,
+        login.register_servlets,
+    ]
+
+    def prepare(
+        self, reactor: MemoryReactor, clock: Clock, homeserver: HomeServer
+    ) -> None:
+        self.manager = homeserver.get_common_usage_metrics_manager()
+
+    def _perform_local_event_actions(self) -> None:
+        """
+        Perform some actions on the homeserver that would bump the CommonUsageMetrics
+        This creates a user, a room, and sends some messages.
+        Expected number of events:
+         - 1 unencrypted messages
+         - 1 encrypted messages
+         - 9 total events (including room state, etc)
+        """
+        # Create user
+        local_user_mxid = self.register_user(
+            username="test_user_1",
+            password="test",
+        )
+        local_user_token = self.login(username=local_user_mxid, password="test")
+
+        # Create a room
+        room_id = self.helper.create_room_as(
+            is_public=False,
+            tok=local_user_token,
+        )
+
+        # Mark the room as end-to-end encrypted
+        self.helper.send_state(
+            room_id=room_id,
+            event_type="m.room.encryption",
+            body={
+                "algorithm": "m.megolm.v1.aes-sha2",
+                "rotation_period_ms": 604800000,
+                "rotation_period_msgs": 100,
+            },
+            state_key="",
+            tok=local_user_token,
+        )
+
+        # Local user sends one unencrypted message
+        self.helper.send(
+            room_id=room_id,
+            body="Unencrypted message",
+            tok=local_user_token,
+        )
+
+        # Local user sends one encrypted message
+        self.helper.send_event(
+            room_id=room_id,
+            type="m.room.encrypted",
+            content={
+                "algorithm": "m.olm.v1.curve25519-aes-sha2",
+                "sender_key": "some_key",
+                "ciphertext": {
+                    "some_key": {
+                        "type": 0,
+                        "body": "encrypted_payload",
+                    },
+                },
+            },
+            tok=local_user_token,
+        )
+
+    def _perform_remote_event_actions(self) -> None:
+        """
+        Perform some actions on the homeserver that would bump the CommonUsageMetrics
+        This creates users, a room, and sends some messages.
+        Expected number of events:
+         - 1 unencrypted messages
+         - 1 encrypted messages
+         - 3 total events (including room state, etc)
+        """
+        OTHER_USER = f"@user:{self.OTHER_SERVER_NAME}"
+        # Create a local user
+        local_user_mxid = self.register_user(
+            username="test_user_1",
+            password="test",
+        )
+        local_user_token = self.login(username=local_user_mxid, password="test")
+
+        # Create a room
+        room_1_id = self.helper.create_room_as(
+            is_public=True,
+            tok=local_user_token,
+        )
+
+        # Allow the remote user to send state events
+        self.helper.send_state(
+            room_1_id,
+            "m.room.power_levels",
+            {"events_default": 0, "state_default": 0},
+            tok=local_user_token,
+        )
+
+        # Make the room as end-to-end encrypted
+        self.helper.send_state(
+            room_id=room_1_id,
+            event_type="m.room.encryption",
+            body={
+                "algorithm": "m.megolm.v1.aes-sha2",
+                "rotation_period_ms": 604800000,
+                "rotation_period_msgs": 100,
+            },
+            state_key="",
+            tok=local_user_token,
+        )
+
+        # Add the remote user to the room
+        self.get_success(
+            event_injection.inject_member_event(self.hs, room_1_id, OTHER_USER, "join")
+        )
+
+        # Send an unencrypted message from the remote user
+        self.get_success(
+            event_injection.inject_event(
+                self.hs,
+                type="m.room.message",
+                state_key="",
+                sender=OTHER_USER,
+                room_id=room_1_id,
+                content={"msgtype": "m.text", "body": "Hello"},
+            )
+        )
+
+        # Send an encrypted message from the remote user
+        self.get_success(
+            event_injection.inject_event(
+                self.hs,
+                type="m.room.encrypted",
+                state_key="",
+                sender=OTHER_USER,
+                room_id=room_1_id,
+                content={
+                    "algorithm": "m.olm.v1.curve25519-aes-sha2",
+                    "sender_key": "some_key",
+                    "ciphertext": {
+                        "some_key": {
+                            "type": 0,
+                            "body": "encrypted_payload",
+                        },
+                    },
+                },
+            )
+        )
+
+    def test_local_event_metrics_update(self) -> None:
+        """
+        Check if the local event metrics are updated correctly after performing actions.
+        """
+        metrics = self.get_success(self.manager.get_metrics())
+        self.assertIsInstance(metrics, CommonUsageMetrics)
+        # Check initial values
+        self.assertEqual(metrics.message_by_local, 0)
+        self.assertEqual(metrics.event_by_local, 0)
+        self.assertEqual(metrics.encrypted_event_by_local, 0)
+
+        self._perform_local_event_actions()
+
+        # Wait for the metrics to be updated
+        self.reactor.advance(5 * 60)
+        metrics = self.get_success(self.manager.get_metrics())
+        self.assertEqual(metrics.message_by_local, 2)
+        self.assertEqual(metrics.event_by_local, 9)
+        self.assertEqual(metrics.encrypted_event_by_local, 1)
+
+    def test_remote_event_metrics_update(self) -> None:
+        """
+        Check if the remote event metrics are updated correctly after performing actions.
+        """
+        metrics = self.get_success(self.manager.get_metrics())
+        self.assertIsInstance(metrics, CommonUsageMetrics)
+        # Check initial values
+        self.assertEqual(metrics.message_by_remote, 0)
+        self.assertEqual(metrics.event_by_remote, 0)
+        self.assertEqual(metrics.encrypted_event_by_remote, 0)
+
+        self._perform_remote_event_actions()
+
+        # Wait for the metrics to be updated
+        self.reactor.advance(5 * 60)
+        metrics = self.get_success(self.manager.get_metrics())
+        self.assertEqual(metrics.message_by_remote, 2)
+        self.assertEqual(metrics.event_by_remote, 3)
+        self.assertEqual(metrics.encrypted_event_by_remote, 1)


### PR DESCRIPTION
# Expose message & event counts in synapse [#3264](https://github.com/famedly/product-management/issues/3264)

- [x] `synapse_messages_by_source`: `select COUNT(*) from events where type = 'm.room.message' or type = 'm.room.encrypted' and sender like '@%:tim-alpha.staging.famedly.de';`, where the like query matches local events vs remote events.
- [x] `synapse_events_by_source`: Same as the above but not filtered by type.
- [x] `synapse_encrypted_by_source`: Same as the above, but only `m.room.encrypted` messages.
- [x] each of those having a local and a remote label:
