### PR TITLE
fix(MSC3911): Handle profile avatars that are unknown gracefully

### DIFF
--- a/synapse/media/media_repository.py
+++ b/synapse/media/media_repository.py
@@ -153,9 +153,13 @@ class AbstractMediaRepository:
                 mxc_uri.server_name, mxc_uri.media_id
             )
         if not media_info:
-            raise SynapseError(404, "Media not found", errcode="M_NOT_FOUND")
+            raise SynapseError(
+                HTTPStatus.NOT_FOUND, "Media not found", errcode=Codes.NOT_FOUND
+            )
         if media_info.quarantined_by:
-            raise SynapseError(404, "Media not found", errcode="M_NOT_FOUND")
+            raise SynapseError(
+                HTTPStatus.NOT_FOUND, "Media not found", errcode=Codes.NOT_FOUND
+            )
         return media_info
 
     async def create_or_update_content(


### PR DESCRIPTION
Related: famedly/product-management#3448

Be more selective about what avatar url's are allowed to be set to the profile of a given user. Particularly around remote media, but any media that is suddenly "missing" could have this error.

Enhance the pre-flight validation to ensure that the media exists, with selective conditions during the transition away from unrestricted media to either ignore the error or forbid the operation.

Gracefully handle updating membership events during a profile avatar change propagation. Most of the potential errors that can be raised here should now be blocked by the pre-flight validation when setting the profile. Additionally, outgoing remote invites and room creator join membership events conditionally drop the avatar url if the media does not exist and legacy unrestricted media is disabled