### PR TITLE
chore: fix Nonetype when the db query doesn't return value

### DIFF
--- a/synapse/metrics/common_usage_metrics.py
+++ b/synapse/metrics/common_usage_metrics.py
@@ -18,6 +18,7 @@
 # [This file includes modifications made by New Vector Limited]
 #
 #
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 import attr
@@ -56,6 +57,15 @@ retained_users_gauge = Gauge(
     "Number of retained users in 30d",
     ["time_range", SERVER_NAME_LABEL],
 )
+
+
+@dataclass
+class UserMetrics:
+    active: int = 0
+    deactivated: int = 0
+    suspended: int = 0
+    locked: int = 0
+    retained_30d: int = 0
 
 
 @attr.s(auto_attribs=True)
@@ -117,17 +127,17 @@ class CommonUsageMetricsManager:
         wau_count = await self._store.count_weekly_users()
         mau_count = await self._store.count_monthly_users()
 
-        user_metric = await self._store.get_user_count_per_status()
+        user_metric: UserMetrics = await self._store.get_user_count_per_status()
 
         return CommonUsageMetrics(
             daily_active_users=dau_count,
             weekly_active_users=wau_count,
             monthly_active_users=mau_count,
-            active_users=user_metric.get("active", 0),
-            deactivated_users=user_metric.get("deactivated", 0),
-            suspended_users=user_metric.get("suspended", 0),
-            locked_users=user_metric.get("locked", 0),
-            monthly_retained_users=user_metric.get("monthly_retained", 0),
+            active_users=user_metric.active,
+            deactivated_users=user_metric.deactivated,
+            suspended_users=user_metric.suspended,
+            locked_users=user_metric.locked,
+            monthly_retained_users=user_metric.retained_30d,
         )
 
     async def _update_gauges(self) -> None:

--- a/tests/storage/databases/main/test_metrics.py
+++ b/tests/storage/databases/main/test_metrics.py
@@ -86,3 +86,19 @@ class ExtremStatisticsTestCase(HomeserverTestCase):
             b'synapse_forward_extremities_gsum{server_name="test"} 10.0',
         ]
         self.assertEqual(items, expected)
+
+
+class UserGaugeTestCase(HomeserverTestCase):
+    def test_get_user_count_per_status_does_not_return_none_value(self) -> None:
+        """
+        Test that get_user_count_per_status never returns None values.
+        """
+        store = self.hs.get_datastores().main
+
+        metrics = self.get_success(store.get_user_count_per_status())
+
+        self.assertIsInstance(metrics.active, int)
+        self.assertIsInstance(metrics.deactivated, int)
+        self.assertIsInstance(metrics.suspended, int)
+        self.assertIsInstance(metrics.locked, int)
+        self.assertIsInstance(metrics.retained_30d, int)


### PR DESCRIPTION
Follow up to the user metric: https://github.com/famedly/synapse/pull/147

There's minor bug that was caused by query result returns None value and was not able to convert it to zero.

```
synapse-1          |   File "/usr/local/lib/python3.12/site-packages/synapse/metrics/background_process_metrics.py", line 276, in run
synapse-1          |     return await func(*args, **kwargs)
synapse-1          |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
synapse-1          |   File "/usr/local/lib/python3.12/site-packages/synapse/metrics/common_usage_metrics.py", line 160, in _update_gauges
synapse-1          |     ).set(float(_metric))
synapse-1          |           ^^^^^^^^^^^^^^
synapse-1          | TypeError: float() argument must be a string or a real number, not 'NoneType'
```