### PR TITLE
Linked Media MSC3911 AP?: Media deletion on redaction

### DIFF
--- a/synapse/handlers/admin.py
+++ b/synapse/handlers/admin.py
@@ -63,6 +63,7 @@ class AdminHandler:
     def __init__(self, hs: "HomeServer"):
         self._store = hs.get_datastores().main
         self._device_handler = hs.get_device_handler()
+        self._media_repository = hs.get_media_repository()
         self._storage_controllers = hs.get_storage_controllers()
         self._state_storage_controller = self._storage_controllers.state
         self._msc3866_enabled = hs.config.experimental.msc3866.enabled
@@ -504,6 +505,10 @@ class AdminHandler:
                         prev_event_ids=[event.event_id],
                         ratelimit=False,
                     )
+                    media_ids = await self._store.get_media_ids_attached_to_event(
+                        event.event_id
+                    )
+                    await self._media_repository.delete_local_media_ids(media_ids)
                 except Exception as ex:
                     logger.info(
                         "Redaction of event %s failed due to: %s", event.event_id, ex

--- a/synapse/handlers/admin.py
+++ b/synapse/handlers/admin.py
@@ -63,7 +63,6 @@ class AdminHandler:
     def __init__(self, hs: "HomeServer"):
         self._store = hs.get_datastores().main
         self._device_handler = hs.get_device_handler()
-        self._media_repository = hs.get_media_repository()
         self._storage_controllers = hs.get_storage_controllers()
         self._state_storage_controller = self._storage_controllers.state
         self._msc3866_enabled = hs.config.experimental.msc3866.enabled
@@ -508,7 +507,8 @@ class AdminHandler:
                     media_ids = await self._store.get_media_ids_attached_to_event(
                         event.event_id
                     )
-                    await self._media_repository.delete_local_media_ids(media_ids)
+                    media_repository = self.hs.get_media_repository()
+                    await media_repository.delete_local_media_ids(media_ids)
                 except Exception as ex:
                     logger.info(
                         "Redaction of event %s failed due to: %s", event.event_id, ex

--- a/synapse/rest/client/room.py
+++ b/synapse/rest/client/room.py
@@ -1325,6 +1325,7 @@ class RoomRedactEventRestServlet(TransactionRestServlet):
         self.event_creation_handler = hs.get_event_creation_handler()
         self.auth = hs.get_auth()
         self._store = hs.get_datastores().main
+        self._media_repository = hs.get_media_repository()
         self._relation_handler = hs.get_relations_handler()
         self._msc3912_enabled = hs.config.experimental.msc3912_enabled
 
@@ -1383,6 +1384,10 @@ class RoomRedactEventRestServlet(TransactionRestServlet):
                 event = await self.event_creation_handler.get_event_from_transaction(
                     requester, txn_id, room_id
                 )
+
+            # Delete any media associated with the event being redacted.
+            media_ids = await self._store.get_media_ids_attached_to_event(event_id)
+            await self._media_repository.delete_local_media_ids(media_ids)
 
             # Event is not yet redacted, create a new event to redact it.
             if event is None:

--- a/synapse/rest/client/room.py
+++ b/synapse/rest/client/room.py
@@ -1322,10 +1322,10 @@ class RoomRedactEventRestServlet(TransactionRestServlet):
 
     def __init__(self, hs: "HomeServer"):
         super().__init__(hs)
+        self.hs = hs
         self.event_creation_handler = hs.get_event_creation_handler()
         self.auth = hs.get_auth()
         self._store = hs.get_datastores().main
-        self._media_repository = hs.get_media_repository()
         self._relation_handler = hs.get_relations_handler()
         self._msc3912_enabled = hs.config.experimental.msc3912_enabled
 
@@ -1387,7 +1387,8 @@ class RoomRedactEventRestServlet(TransactionRestServlet):
 
             # Delete any media associated with the event being redacted.
             media_ids = await self._store.get_media_ids_attached_to_event(event_id)
-            await self._media_repository.delete_local_media_ids(media_ids)
+            media_repository = self.hs.get_media_repository()
+            await media_repository.delete_local_media_ids(media_ids)
 
             # Event is not yet redacted, create a new event to redact it.
             if event is None:

--- a/synapse/storage/databases/main/media_repository.py
+++ b/synapse/storage/databases/main/media_repository.py
@@ -45,6 +45,7 @@ from synapse.storage.database import (
     LoggingDatabaseConnection,
     LoggingTransaction,
 )
+from synapse.storage.engines import PostgresEngine
 from synapse.types import JsonDict, UserID
 from synapse.util import json_encoder
 
@@ -1307,4 +1308,34 @@ class MediaRepositoryStore(MediaRepositoryBackgroundUpdateStore):
             server_name=server_name,
             media_id=media_id,
             json_dict=json_object,
+        )
+
+    async def get_media_ids_attached_to_event(self, event_id: str) -> list[str]:
+        """
+        Get a list of media_ids that are attached to a specific event_id.
+        Automatically chooses the query based on database engine.
+        """
+        # TODO: does server_name matters?
+
+        def get_media_ids_attached_to_event_txn(txn: LoggingTransaction) -> list[str]:
+            if isinstance(self.db_pool.engine, PostgresEngine):
+                # Use GIN index for Postgres
+                sql = """
+                SELECT media_id
+                FROM media_attachments
+                WHERE restrictions_json @> '{"restrictions": {"event_id": ?}}'
+                """
+            else:
+                # Use cross-database compatible query for the rest
+                sql = """
+                SELECT media_id
+                FROM media_attachments
+                WHERE restrictions_json->'restrictions'->>'event_id' = ?
+                """
+            txn.execute(sql, (event_id,))
+            return [row[0] for row in txn.fetchall()]
+
+        return await self.db_pool.runInteraction(
+            "get_media_ids_attached_to_event",
+            get_media_ids_attached_to_event_txn,
         )

--- a/tests/rest/client/test_redactions.py
+++ b/tests/rest/client/test_redactions.py
@@ -78,6 +78,8 @@ class RedactionsTestCase(HomeserverTestCase):
         self.helper.join(
             room=self.room_id, user=self.other_user_id, tok=self.other_access_token
         )
+        self.media_repo = hs.get_media_repository()
+        self.store = hs.get_datastores().main
 
     def _redact_event(
         self,
@@ -656,3 +658,9 @@ class RedactionsTestCase(HomeserverTestCase):
         else:
             self.assertEqual(event_json["redacts"], event_id)
             self.assertNotIn("redacts", event_json["content"])
+
+    @override_config({"experimental_features": {"msc3911_enabled": True}})
+    def test_redaction_deletes_attached_media(self) -> None:
+        # TODO: support a delay for moderators,
+        # redacted media should still be available for moderators, then the media deleted later.
+        pass

--- a/tests/rest/client/test_relations.py
+++ b/tests/rest/client/test_relations.py
@@ -35,6 +35,7 @@ from synapse.util import Clock
 from tests import unittest
 from tests.server import FakeChannel
 from tests.test_utils.event_injection import inject_event
+from tests.unittest import override_config
 
 
 class BaseRelationsTestCase(unittest.HomeserverTestCase):
@@ -1790,6 +1791,10 @@ class RelationRedactionTestCase(BaseRelationsTestCase):
             relations[RelationTypes.THREAD]["latest_event"]["event_id"],
             related_event_id,
         )
+
+    @override_config({"experimental_features": {"msc3912_enabled": True}})
+    def test_redact_all_relations_deletes_attached_media_on_relations(self) -> None:
+        pass
 
 
 class ThreadsTestCase(BaseRelationsTestCase):


### PR DESCRIPTION
# Linked Media MSC3911 AP?: Media deletion on redaction [#3366](https://github.com/famedly/product-management/issues/3366)

- [x] When an event is redacted, media attached to it should also be deleted.
- [ ] When the content of an event would be redacted (because of a redaction), the attached media should also be deleted. This should apply to local and remote media.
- [ ] We may need to support a delay for moderators, in which case downloads should be immediately restricted for normal users and still be available for moderators, then the media deleted later.