### PR TITLE
Additions to Media de-duplication efforts

### DIFF
--- a/.github/workflows/famedly-tests.yml
+++ b/.github/workflows/famedly-tests.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: Swatinem/rust-cache@68b3cb7503c78e67dae8373749990a220eb65352
       - uses: matrix-org/setup-python-poetry@v2
         with:
-          python-version: "3.x"
+          python-version: "3.13"
           poetry-version: "2.1.1"
           extras: "all"
       - run: poetry run scripts-dev/generate_sample_config.sh --check
@@ -49,7 +49,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.x"
+          python-version: "3.13"
       - run: .ci/scripts/check_lockfile.py
 
   lint:
@@ -63,6 +63,7 @@ jobs:
         uses: matrix-org/setup-python-poetry@v2
         with:
           poetry-version: "2.1.1"
+          python-version: "3.13"
           install-project: "false"
 
       - name: Run ruff check
@@ -91,6 +92,7 @@ jobs:
           # https://github.com/matrix-org/synapse/pull/15376#issuecomment-1498983775
           # To make CI green, err towards caution and install the project.
           install-project: "true"
+          python-version: "3.13"
           poetry-version: "2.1.1"
 
       # Cribbed from
@@ -124,6 +126,7 @@ jobs:
       - uses: matrix-org/setup-python-poetry@v2
         with:
           poetry-version: "2.1.1"
+          python-version: "3.13"
           extras: "all"
       - run: poetry run scripts-dev/check_pydantic_models.py
 
@@ -161,7 +164,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.x"
+          python-version: "3.13"
       - run: "pip install rstcheck"
       - run: "rstcheck --report-level=WARNING README.rst"
 

--- a/rust/src/http_client.rs
+++ b/rust/src/http_client.rs
@@ -137,7 +137,7 @@ fn get_runtime<'a>(reactor: &Bound<'a, PyAny>) -> PyResult<PyRef<'a, PyTokioRunt
 static DEFER: OnceCell<PyObject> = OnceCell::new();
 
 /// Access to the `twisted.internet.defer` module.
-fn defer(py: Python<'_>) -> PyResult<&Bound<PyAny>> {
+fn defer(py: Python<'_>) -> PyResult<&Bound<'_, PyAny>> {
     Ok(DEFER
         .get_or_try_init(|| py.import("twisted.internet.defer").map(Into::into))?
         .bind(py))

--- a/synapse/media/media_storage.py
+++ b/synapse/media/media_storage.py
@@ -226,7 +226,7 @@ class MediaStorage:
                 # .. write into f ...
         """
         # With `use_sha256_path` enabled, new files are stored with SHA256 paths.
-        path = self._file_info_to_path(file_info)
+        path = self.resolve_path_to_media_file(file_info)
         fname = os.path.join(self.local_media_directory, path)
         dirname = os.path.dirname(fname)
         os.makedirs(dirname, exist_ok=True)
@@ -251,9 +251,12 @@ class MediaStorage:
                     # the spam-check API.
                     raise SpamMediaException(errcode=spam_check[0])
 
+                # Unlike the local cache, the storage providers are on their own for
+                # de-duplicating media. They get a relative path to work with
+                relative_legacy_path = self._file_info_to_path(file_info)
                 for provider in self.storage_providers:
                     with start_active_span(str(provider)):
-                        await provider.store_file(path, file_info)
+                        await provider.store_file(relative_legacy_path, file_info)
 
         except Exception as e:
             try:
@@ -273,10 +276,7 @@ class MediaStorage:
         Returns:
             Returns a Responder if the file was found, otherwise None.
         """
-        paths = [self._file_info_to_path(file_info, force_sha256=False)]
-
-        if self.use_sha256_path:
-            paths.append(self._file_info_to_path(file_info))
+        paths = [self.resolve_path_to_media_file(file_info)]
 
         # fallback for remote thumbnails with no method in the filename
         if file_info.thumbnail and file_info.server_name:
@@ -297,6 +297,10 @@ class MediaStorage:
                 return FileResponder(self.hs, open(local_path, "rb"))
             logger.debug("local file %s did not exist", local_path)
 
+        # Unlike the local cache, the storage providers are on their own for
+        # de-duplicating media. They get a relative path to work with
+        relative_legacy_path = self._file_info_to_path(file_info)
+        paths = [relative_legacy_path]
         for provider in self.storage_providers:
             for path in paths:
                 res: Any = await provider.fetch(path, file_info)
@@ -318,14 +322,7 @@ class MediaStorage:
         Returns:
             Full path to local file
         """
-        # When `use_sha256_path` is enabled, we first check for the SHA256 path.
-        if self.use_sha256_path and not file_info.url_cache:
-            path = self._file_info_to_path(file_info)
-            local_path = os.path.join(self.local_media_directory, path)
-            if os.path.exists(local_path):
-                return local_path
-
-        path = self._file_info_to_path(file_info, force_sha256=False)
+        path = self.resolve_path_to_media_file(file_info)
         local_path = os.path.join(self.local_media_directory, path)
         if os.path.exists(local_path):
             return local_path
@@ -347,8 +344,11 @@ class MediaStorage:
         dirname = os.path.dirname(local_path)
         os.makedirs(dirname, exist_ok=True)
 
+        # Unlike the local cache, the storage providers are on their own for
+        # de-duplicating media. They get a relative path to work with
+        relative_legacy_path = self._file_info_to_path(file_info)
         for provider in self.storage_providers:
-            res: Any = await provider.fetch(path, file_info)
+            res: Any = await provider.fetch(relative_legacy_path, file_info)
             if res:
                 with res:
                     consumer = BackgroundFileConsumer(
@@ -361,9 +361,7 @@ class MediaStorage:
         raise NotFoundError()
 
     @trace
-    def _file_info_to_path(
-        self, file_info: FileInfo, force_sha256: Optional[bool] = None
-    ) -> str:
+    def _file_info_to_path(self, file_info: FileInfo) -> str:
         """
         Converts file_info to a relative path.
 
@@ -372,22 +370,7 @@ class MediaStorage:
 
         Args:
             file_info: File information
-            force_sha256: If True, force SHA256 path; if False, force media_id path,
-                        if None, use self.use_sha256_path flag.
         """
-        use_sha256 = force_sha256 if force_sha256 is not None else self.use_sha256_path
-        if use_sha256 and file_info.sha256 and not file_info.url_cache:
-            if file_info.thumbnail:
-                return self.filepaths.thumbnail_sha_rel(
-                    sha256=file_info.sha256,
-                    width=file_info.thumbnail.width,
-                    height=file_info.thumbnail.height,
-                    content_type=file_info.thumbnail.type,
-                    method=file_info.thumbnail.method,
-                )
-            return self.filepaths.filepath_sha_rel(file_info.sha256)
-
-        # Fall back to media_id-based paths
         if file_info.url_cache:
             if file_info.thumbnail:
                 return self.filepaths.url_cache_thumbnail_rel(
@@ -422,6 +405,130 @@ class MediaStorage:
                 method=file_info.thumbnail.method,
             )
         return self.filepaths.local_media_filepath_rel(file_info.file_id)
+
+    def _file_info_to_sha256_path(self, file_info: FileInfo) -> str:
+        """
+        Resolve the path based on the sha256 hash. This does not work for the url cache.
+
+        Returns:
+            The relative path to where the file should be
+        """
+        # There should not be a case where a url preview should be cached in sha256
+        assert not file_info.url_cache, "Can not use sha256 paths with url caching"
+
+        assert file_info.sha256 is not None, (
+            "Can not resolve a path to a sha256 object without a hash"
+        )
+        if file_info.thumbnail:
+            return self.filepaths.thumbnail_sha_rel(
+                sha256=file_info.sha256,
+                width=file_info.thumbnail.width,
+                height=file_info.thumbnail.height,
+                content_type=file_info.thumbnail.type,
+                method=file_info.thumbnail.method,
+            )
+        return self.filepaths.filepath_sha_rel(file_info.sha256)
+
+    def resolve_path_to_media_file(self, file_info: FileInfo) -> str:
+        """
+        Fully resolve the filesystem path to the media object. Allow for backwards
+        compatibility with existing media_id-based file names.
+
+        Arguments:
+            file_info: The FileInfo object that contains the data for looking up the
+                file path
+        Returns:
+            The fully resolved, relative path to the file request.
+        """
+
+        media_id_path = self._file_info_to_path(file_info)
+
+        if not file_info.sha256 or file_info.url_cache:
+            return media_id_path
+        sha256_path = self._file_info_to_sha256_path(file_info)
+
+        media_id_abs_path = os.path.join(self.local_media_directory, media_id_path)
+        media_id_file_exists = os.path.exists(media_id_abs_path)
+
+        sha256_abs_path = os.path.join(self.local_media_directory, sha256_path)
+        sha256_file_exists = os.path.exists(sha256_abs_path)
+
+        logger.debug(
+            "Verifying media file exists at path %s: %r",
+            media_id_abs_path,
+            media_id_file_exists,
+        )
+        logger.debug(
+            "Verifying media file exists at sha256 path %s: %r",
+            sha256_abs_path,
+            sha256_file_exists,
+        )
+
+        # When `use_sha256_path` is not enabled, but might have been in the past, use
+        # that file if it already exists. Perhaps the admin changed their mind?
+        if sha256_file_exists:
+            return sha256_path
+        if media_id_file_exists:
+            return media_id_path
+        return sha256_path if self.use_sha256_path else media_id_path
+
+    async def maybe_move_media_file_from_id_to_sha256_path(
+        self, file_info: FileInfo
+    ) -> None:
+        """
+        Move a media file from a legacy "media_id" based path to a "sha256" based path.
+        This is most appropriate after using `store_into_file()` for federation
+        downloaded media.
+        """
+        # Check the old media id path for the file, then check the sha256 path.
+        # If media exists on the old path, and use_sha256_path is enabled, move
+        # the file. Migration is one way
+
+        if not self.use_sha256_path:
+            logger.debug("Can not move media file if de-deduplication turned off")
+            return
+        if not file_info.sha256:
+            logger.warning(
+                "Sha256 data on media/file id '%s' is missing. Skipping file move",
+                file_info.file_id,
+            )
+            return
+
+        media_id_path = self._file_info_to_path(file_info)
+        media_id_abs_path = os.path.join(self.local_media_directory, media_id_path)
+        media_id_file_exists = os.path.exists(media_id_abs_path)
+        logger.debug(
+            "Verifying media file exists at path %s: %r",
+            media_id_abs_path,
+            media_id_file_exists,
+        )
+
+        sha256_path = self._file_info_to_sha256_path(file_info)
+        sha256_abs_path = os.path.join(self.local_media_directory, sha256_path)
+        sha256_file_exists = os.path.exists(sha256_abs_path)
+        logger.debug(
+            "Verifying media file exists at sha256 path %s: %r",
+            sha256_abs_path,
+            sha256_file_exists,
+        )
+
+        if media_id_file_exists and not sha256_file_exists:
+            os.makedirs(os.path.dirname(sha256_abs_path), exist_ok=True)
+            # os.rename() should be an atomic operation
+            os.rename(media_id_abs_path, sha256_abs_path)
+            logger.debug(
+                "Moved file from old media id path to new sha256 path: %s",
+                sha256_abs_path,
+            )
+
+        # Having `use_sha256_path` enabled is our signal that the server prefers using
+        # the newer path style
+        if media_id_file_exists and sha256_file_exists:
+            # Probably should clean up the old duplicate? Do we want a feature flag?
+            os.remove(media_id_abs_path)
+            logger.debug(
+                "Both paths existed, deleting old media id path: %s", media_id_abs_path
+            )
 
 
 @trace

--- a/synapse/media/thumbnailer.py
+++ b/synapse/media/thumbnailer.py
@@ -392,6 +392,7 @@ class ThumbnailProvider:
                     file_id=media_id,
                     url_cache=bool(media_info.url_cache),
                     thumbnail=info,
+                    sha256=media_info.sha256,
                 )
 
                 responder = await self.media_storage.fetch_media(file_info)
@@ -507,6 +508,7 @@ class ThumbnailProvider:
                     server_name=server_name,
                     file_id=file_id,
                     thumbnail=info,
+                    sha256=media_info.sha256,
                 )
 
                 responder = await self.media_storage.fetch_media(file_info)
@@ -527,7 +529,7 @@ class ThumbnailProvider:
             desired_height,
             desired_method,
             desired_type,
-            media_info.sha256 if self.use_sha256_path else None,
+            media_info.sha256,
         )
 
         if file_path:
@@ -596,9 +598,7 @@ class ThumbnailProvider:
             url_cache=False,
             server_name=server_name,
             for_federation=False,
-            sha256=media_info.sha256
-            if self.use_sha256_path and media_info.sha256
-            else None,
+            sha256=media_info.sha256,
         )
 
     async def _select_and_respond_with_thumbnail(
@@ -658,7 +658,7 @@ class ThumbnailProvider:
                 file_id,
                 url_cache,
                 server_name,
-                sha256=sha256 if self.use_sha256_path and sha256 else None,
+                sha256=sha256,
             )
             if not file_info:
                 logger.info("Couldn't find a thumbnail matching the desired inputs")

--- a/synapse/storage/databases/main/media_repository.py
+++ b/synapse/storage/databases/main/media_repository.py
@@ -1309,8 +1309,9 @@ class MediaRepositoryStore(MediaRepositoryBackgroundUpdateStore):
             json_dict=json_object,
         )
 
-    async def get_sha_by_media_id(
-        self, media_id: str, server_name: Optional[str] = None
+    async def get_sha_for_local_media_id(
+        self,
+        media_id: str,
     ) -> str:
         """
         Get the media ID of and return SHA256 hash of given media.
@@ -1322,22 +1323,10 @@ class MediaRepositoryStore(MediaRepositoryBackgroundUpdateStore):
         LIMIT 1
         """
 
-        if server_name and not self.hs.is_mine_server_name(server_name):
-            sql = """
-            SELECT sha256
-            FROM remote_media_cache
-            WHERE media_origin = ? AND media_id = ?
-            ORDER BY created_ts ASC
-            LIMIT 1
-            """
-
-        def _get_sha_by_media_id_txn(
+        def _get_sha_for_local_media_id_txn(
             txn: LoggingTransaction,
         ) -> str:
-            if server_name and not self.hs.is_mine_server_name(server_name):
-                txn.execute(sql, (server_name, media_id))
-            else:
-                txn.execute(sql, (media_id,))
+            txn.execute(sql, (media_id,))
 
             rows = txn.fetchone()
             if not rows:
@@ -1345,5 +1334,58 @@ class MediaRepositoryStore(MediaRepositoryBackgroundUpdateStore):
             return rows[0]
 
         return await self.db_pool.runInteraction(
-            "get_sha_by_media_id", _get_sha_by_media_id_txn
+            "get_sha_for_local_media_id", _get_sha_for_local_media_id_txn
+        )
+
+    async def get_sha_for_remote_media_id(self, server_name: str, media_id: str) -> str:
+        """
+        Get the media ID of and return SHA256 hash of given media.
+        """
+        assert not self.hs.is_mine_server_name(server_name), (
+            "Can not run against own server"
+        )
+        sql = """
+        SELECT sha256
+        FROM remote_media_cache
+        WHERE media_origin = ? AND media_id = ?
+        ORDER BY created_ts ASC
+        LIMIT 1
+        """
+
+        def _get_sha_for_remote_media_id_txn(
+            txn: LoggingTransaction,
+        ) -> str:
+            txn.execute(sql, (server_name, media_id))
+
+            rows = txn.fetchone()
+            if not rows:
+                raise ValueError("media_id %s has no sha256 field", media_id)
+            return rows[0]
+
+        return await self.db_pool.runInteraction(
+            "get_sha_for_remote_media_id", _get_sha_for_remote_media_id_txn
+        )
+
+    async def get_media_reference_count_for_sha256(self, sha256: str) -> int:
+        """Get total number of local + remote media entries for this SHA256."""
+
+        def _get_reference_count_txn(txn: LoggingTransaction) -> int:
+            sql = """
+            SELECT SUM(total_rows) AS grand_total_rows
+            FROM (
+                SELECT COUNT(*) AS total_rows FROM local_media_repository WHERE sha256 = ?
+                UNION ALL
+                SELECT COUNT(*) AS total_rows FROM remote_media_cache WHERE sha256 = ?
+            ) AS combined_counts
+            """
+
+            txn.execute(sql, (sha256, sha256))
+            row_tuple = txn.fetchone()
+            if row_tuple is not None:
+                (row,) = row_tuple
+                return row
+            return 0
+
+        return await self.db_pool.runInteraction(
+            "get_media_reference_count_for_sha256", _get_reference_count_txn
         )

--- a/tests/rest/client/test_media.py
+++ b/tests/rest/client/test_media.py
@@ -5162,39 +5162,60 @@ class MediaStorageSha256PathCompatTestCase(unittest.HomeserverTestCase):
 
     def _create_local_media_with_sha256_path(self) -> str:
         assert isinstance(self.repo, MediaRepository)
+        media_id = random_string(24)
+        # Curate a specialized FileInfo that includes sha256 data, then file will be
+        # forced to the new sha256 path
+        file_info = FileInfo(
+            server_name=None,
+            file_id=media_id,
+            sha256=SMALL_PNG_SHA256,
+        )
+
         expected_path = self.repo.filepaths.filepath_sha(SMALL_PNG_SHA256)
-        mxc_uri = self.get_success(
-            self.repo.create_or_update_content(
+        ctx = self.repo.media_storage.store_into_file(file_info)
+        (f, fname) = self.get_success(ctx.__aenter__())
+        f.write(SMALL_PNG)
+        self.get_success(ctx.__aexit__(None, None, None))
+
+        # Insert the appropriate data into the database, so lookups work as expected
+        self.get_success(
+            self.repo.store.store_local_media(
+                media_id=media_id,
                 media_type="image/png",
-                upload_name="test_png_upload",
-                content=io.BytesIO(SMALL_PNG),
-                content_length=67,
-                auth_user=UserID.from_string(self.user),
-                media_id=None,
-                restricted=True,
+                time_now_ms=self.clock.time_msec(),
+                upload_name="original_media",
+                media_length=67,
+                user_id=UserID.from_string(self.user),
+                sha256=SMALL_PNG_SHA256,
+                quarantined_by=None,
+                restricted=False,
             )
         )
+        assert expected_path == fname
+        assert os.path.exists(fname), f"File does not exist: {fname}"
         assert os.path.exists(expected_path), f"File does not exist: {expected_path}"
-        assert not os.path.exists(
-            self.repo.filepaths.local_media_filepath(mxc_uri.media_id)
+
+        # Some tests expect thumbnails, remember to generate them
+        self.get_success(
+            self.repo._generate_thumbnails(
+                server_name=None,
+                media_id=media_id,
+                file_id=media_id,
+                media_type="image/png",
+                # We purposely do not use the sha256 here, as it directly causes the sha256
+                # path for thumbnails to be populated, and that is not what we are looking
+                # for.
+                sha256=SMALL_PNG_SHA256,
+            )
         )
-        return mxc_uri.media_id
+
+        return media_id
 
     def _create_local_media_with_media_id_path(self) -> str:
         assert isinstance(self.repo, MediaRepository)
-        self.repo.use_sha256_path = False
-        mxc_uri = self.get_success(
-            self.repo.create_or_update_content(
-                media_type="image/png",
-                upload_name="original_media",
-                content=io.BytesIO(SMALL_PNG),
-                content_length=67,
-                auth_user=UserID.from_string(self.user),
-                media_id=None,
-                restricted=True,
-            )
-        )
-        media_id = mxc_uri.media_id
+        media_id = random_string(24)
+        # Curate a specialized FileInfo that is lacking sha256 data, then file will be
+        # forced to the old media_id path
         file_info = FileInfo(
             server_name=None,
             file_id=media_id,
@@ -5206,10 +5227,37 @@ class MediaStorageSha256PathCompatTestCase(unittest.HomeserverTestCase):
         f.write(SMALL_PNG)
         self.get_success(ctx.__aexit__(None, None, None))
 
+        # Insert the appropriate data into the database, so lookups work as expected
+        self.get_success(
+            self.repo.store.store_local_media(
+                media_id=media_id,
+                media_type="image/png",
+                time_now_ms=self.clock.time_msec(),
+                upload_name="original_media",
+                media_length=67,
+                user_id=UserID.from_string(self.user),
+                sha256=SMALL_PNG_SHA256,
+                quarantined_by=None,
+                restricted=False,
+            )
+        )
         assert expected_path == fname
         assert os.path.exists(fname), f"File does not exist: {fname}"
         assert os.path.exists(expected_path), f"File does not exist: {expected_path}"
-        self.repo.use_sha256_path = True
+
+        # Some tests expect thumbnails, remember to generate them
+        self.get_success(
+            self.repo._generate_thumbnails(
+                server_name=None,
+                media_id=media_id,
+                file_id=media_id,
+                media_type="image/png",
+                # We purposely do not use the sha256 here, as it directly causes the sha256
+                # path for thumbnails to be populated, and that is not what we are looking
+                # for.
+                sha256=None,
+            )
+        )
         return media_id
 
     async def _mock_federation_download_media(
@@ -5263,11 +5311,13 @@ class MediaStorageSha256PathCompatTestCase(unittest.HomeserverTestCase):
             )
         )
 
-    def test_download_local_media_with_media_id_path_saves_file_in_sha256_path(
+    def test_download_local_media_with_media_id_path(
         self,
     ) -> None:
-        """Test that downloading local media with media_id path saves file in sha256 path."""
-        # Create local media with media_id path.
+        """Test that downloading local media with media_id path serves correct file."""
+        # Specifically, that a preexisting file on the legacy media paths can still be
+        # served from its present location.
+
         media_id = self._create_local_media_with_media_id_path()
         channel = self.make_request(
             "GET",
@@ -5277,12 +5327,9 @@ class MediaStorageSha256PathCompatTestCase(unittest.HomeserverTestCase):
         )
         assert channel.code == 200
         assert channel.result["body"] == SMALL_PNG
-        assert isinstance(self.repo, MediaRepository)
-        # Downloading local media with media_id path doesn't recreate the file in the sha256 path.
-        assert os.path.exists(self.repo.filepaths.local_media_filepath(media_id))
 
     def test_download_local_media_with_sha256_path(self) -> None:
-        """Test that downloading local media with sha256 path saves file in sha256 path."""
+        """Test that downloading local media with sha256 path serves correct file."""
         media_id = self._create_local_media_with_sha256_path()
         channel = self.make_request(
             "GET",
@@ -5292,9 +5339,6 @@ class MediaStorageSha256PathCompatTestCase(unittest.HomeserverTestCase):
         )
         assert channel.code == 200
         assert channel.result["body"] == SMALL_PNG
-        assert isinstance(self.repo, MediaRepository)
-        assert os.path.exists(self.repo.filepaths.filepath_sha(SMALL_PNG_SHA256))
-        assert not os.path.exists(self.repo.filepaths.local_media_filepath(media_id))
 
     def test_copy_remote_media_with_sha256_path(self) -> None:
         """Test that copying remote media saves file in sha256 path."""
@@ -5323,7 +5367,7 @@ class MediaStorageSha256PathCompatTestCase(unittest.HomeserverTestCase):
         )
         assert remote_media is not None
         assert remote_media.sha256 == SMALL_PNG_SHA256
-        assert remote_media.filesystem_id == SMALL_PNG_SHA256
+
         copied_media = self.get_success(
             self.repo.store.get_local_media(copied_media_mxc_uri.media_id)
         )
@@ -5333,6 +5377,7 @@ class MediaStorageSha256PathCompatTestCase(unittest.HomeserverTestCase):
         # Check if the file is saved in the sha256 path only.
         assert isinstance(self.repo, MediaRepository)
         assert os.path.exists(self.repo.filepaths.filepath_sha(SMALL_PNG_SHA256))
+        # It should NOT exist in either of the legacy paths
         assert not os.path.exists(
             self.repo.filepaths.remote_media_filepath(
                 remote_server, remote_media.filesystem_id
@@ -5373,9 +5418,8 @@ class MediaStorageSha256PathCompatTestCase(unittest.HomeserverTestCase):
         # The copy should create a new media id, and recreate the file in the sha256 path.
         assert isinstance(self.repo, MediaRepository)
         assert os.path.exists(self.repo.filepaths.filepath_sha(SMALL_PNG_SHA256))
-        assert os.path.exists(
-            self.repo.filepaths.local_media_filepath(media_id)
-        )  # Copy operation does not delete the original file with media_id path.
+        assert os.path.exists(self.repo.filepaths.local_media_filepath(media_id))
+        # Copy operation does not delete the original file with media_id path.
         assert not os.path.exists(
             self.repo.filepaths.local_media_filepath(copied_media_mxc_uri.media_id)
         )
@@ -5435,13 +5479,14 @@ class MediaStorageSha256PathCompatTestCase(unittest.HomeserverTestCase):
         _, media_id = res.rsplit("/", maxsplit=1)
 
         # Check if the media is saved in the media table.
-        media = self.get_success(self.repo.store.get_local_media(media_id))
-        assert media is not None
-        assert media.sha256 == SMALL_PNG_SHA256
+        local_media_info = self.get_success(self.repo.store.get_local_media(media_id))
+        assert local_media_info is not None
+        assert local_media_info.sha256 == SMALL_PNG_SHA256
 
         # Check if the file is saved in the sha256 path.
         assert isinstance(self.repo, MediaRepository)
         assert os.path.exists(self.repo.filepaths.filepath_sha(SMALL_PNG_SHA256))
+        # It should not be created on the legacy path
         assert not os.path.exists(self.repo.filepaths.local_media_filepath(media_id))
 
     def test_download_local_thumbnail_with_media_id(self) -> None:
@@ -5458,17 +5503,6 @@ class MediaStorageSha256PathCompatTestCase(unittest.HomeserverTestCase):
         )
         assert channel.code == 200, channel.result
         assert channel.result["body"] is not None
-
-        # Check if the thumbnail is saved in the media_id path, not in the sha256 path.
-        assert isinstance(self.repo, MediaRepository)
-        assert os.path.exists(
-            self.repo.filepaths.local_media_thumbnail(
-                media_id, 1, 1, "image/png", "scale"
-            )
-        )
-        assert not os.path.exists(
-            self.repo.filepaths.thumbnail_sha(media_id, 1, 1, "image/png", "scale")
-        )
 
     def test_download_local_thumbnail_with_sha256_path(self) -> None:
         """Test downloading thumbnail of local media with sha256 path."""


### PR DESCRIPTION
A little bit of clean up. Abstracting how the local path to the file is resolved. Ensure consistency when removing media, that if there are still references to the media that only the metadata is removed until it is the last reference.

Resolving concerns about moving existing media by leaving it in place and only new media is de-duplicated.

Stage incoming remote media into it's legacy file path until the sha256 can be discovered, and only after it is written to the database metadata is it moved into it's new place. This specific set of steps works with the file path resolving, so if the moving process is interrupted it will still be usable.

Always provide `StorageProvider` classes with a consistent relative "path". For a media id of `1234567890`, it would break down to `12/34/567890`. Do not use the sha256 for this path. `StorageProvider`s are provided the `FileInfo` class as well, if they want to do media de-dupe they can get it from there. Should we provide an enhancement to the bundled `StorageProvider` to allow for this capability?

Depends on #155 