### PR TITLE
MSC3911: Handle media that are attached to redacted media

### DIFF
--- a/synapse/config/experimental.py
+++ b/synapse/config/experimental.py
@@ -592,7 +592,12 @@ class ExperimentalConfig(Config):
         # MSC3911: Linking Media to Events
         self.msc3911_enabled: bool = experimental.get("msc3911_enabled", False)
 
-        # Disable the current media create and upload endpoints
+        # MSC3911: Disable the current media create and upload endpoints
         self.msc3911_unrestricted_media_upload_disabled: bool = experimental.get(
             "msc3911_unrestricted_media_upload_disabled", False
+        )
+
+        # MSC3911: Retention time for media that are attached to redacted events
+        self.msc3911_redacted_event_media_cleanup_interval: int = experimental.get(
+            "msc3911_redacted_event_media_cleanup_interval", 48 * 60 * 60 * 1000
         )

--- a/synapse/handlers/events.py
+++ b/synapse/handlers/events.py
@@ -156,14 +156,17 @@ class EventHandler:
         event_id: str,
         show_redacted: bool = False,
     ) -> Optional[EventBase]:
-        """Retrieve a single specified event.
+        """Retrieve a single specified event from the database, depending on the
+        show_redacted flag, it either hides or exposes redacted content.
 
         Args:
             user: The local user requesting the event
             room_id: The expected room id. We'll return None if the
                 event's room does not match.
             event_id: The event ID to obtain.
-            show_redacted: Should the full content of redacted events be returned?
+            show_redacted: If False (default), the returned event will have its redacted
+                content removed as users normally see it. When True, the event will be
+                returned exactly as stored, even if it’s been redacted.
         Returns:
             An event, or None if there is no event matching this ID.
         Raises:

--- a/synapse/media/media_repository.py
+++ b/synapse/media/media_repository.py
@@ -319,11 +319,7 @@ class AbstractMediaRepository:
         Verify that media requested for download should be visible to the user making
         the request
         """
-        # Handle both string and UserID types for requester.user
-        if isinstance(requester.user, UserID):
-            requester_user_id_str = requester.user.to_string()
-        else:
-            requester_user_id_str = str(requester.user)  # type: ignore
+        requester_user_id_str = requester.user.to_string()
         if not self.enable_media_restriction:
             return
 
@@ -349,12 +345,8 @@ class AbstractMediaRepository:
                 f"Media requested ('{media_info_object.media_id}') is restricted"
             )
 
-        attachments = media_info_object.attachments.to_dict().get(
-            "org.matrix.msc3911.restrictions", {}
-        )
-        # Safely extract values from the nested structure, handling missing keys
-        attached_event_id = attachments.get("event_id")
-        attached_profile_user_id = attachments.get("profile_user_id")
+        attached_event_id = media_info_object.attachments.event_id
+        attached_profile_user_id = media_info_object.attachments.profile_user_id
 
         if attached_event_id:
             # Check if event is redacted or not. If it is redacted, normal user no

--- a/synapse/media/thumbnailer.py
+++ b/synapse/media/thumbnailer.py
@@ -305,7 +305,7 @@ class ThumbnailProvider:
             if requester is not None:
                 # Only check media visibility if this is for a local request. This will
                 # raise directly back to the client if not visible
-                await self.media_repo.is_media_visible(requester.user, media_info)
+                await self.media_repo.is_media_visible(requester, media_info)
             restrictions = await self.media_repo.validate_media_restriction(
                 request, media_info, None, for_federation
             )
@@ -365,7 +365,7 @@ class ThumbnailProvider:
             if requester is not None:
                 # Only check media visibility if this is for a local request. This will
                 # raise directly back to the client if not visible
-                await self.media_repo.is_media_visible(requester.user, media_info)
+                await self.media_repo.is_media_visible(requester, media_info)
             restrictions = await self.media_repo.validate_media_restriction(
                 request, None, media_id, for_federation
             )
@@ -482,7 +482,7 @@ class ThumbnailProvider:
         # if MSC3911 is enabled, check visibility of the media for the user
         if self.enable_media_restriction and requester is not None:
             # This will raise directly back to the client if not visible
-            await self.media_repo.is_media_visible(requester.user, media_info)
+            await self.media_repo.is_media_visible(requester, media_info)
 
         # Check if the media is cached on the client, if so return 304.
         if check_for_cached_entry_and_respond(request):
@@ -572,7 +572,7 @@ class ThumbnailProvider:
         # if MSC3911 is enabled, check visibility of the media for the user
         if self.enable_media_restriction and requester is not None:
             # This will raise directly back to the client if not visible
-            await self.media_repo.is_media_visible(requester.user, media_info)
+            await self.media_repo.is_media_visible(requester, media_info)
 
         # Check if the media is cached on the client, if so return 304.
         if check_for_cached_entry_and_respond(request):

--- a/synapse/rest/admin/media.py
+++ b/synapse/rest/admin/media.py
@@ -282,9 +282,10 @@ class DeleteMediaByID(RestServlet):
 
         logger.info("Deleting local media by ID: %s", media_id)
 
-        deleted_media, total = await self.media_repository.delete_local_media_ids(
-            [media_id]
-        )
+        (
+            deleted_media,
+            total,
+        ) = await self.media_repository.delete_media_from_disk_by_media_ids([media_id])
         return HTTPStatus.OK, {"deleted_media": deleted_media, "total": total}
 
 
@@ -446,7 +447,10 @@ class UserMediaRestServlet(RestServlet):
             start, limit, user_id, order_by, direction
         )
 
-        deleted_media, total = await self.media_repository.delete_local_media_ids(
+        (
+            deleted_media,
+            total,
+        ) = await self.media_repository.delete_media_from_disk_by_media_ids(
             [m.media_id for m in media]
         )
 

--- a/synapse/storage/databases/main/media_repository.py
+++ b/synapse/storage/databases/main/media_repository.py
@@ -74,15 +74,15 @@ class MediaRestrictions:
     """
 
     event_id: Optional[str] = None
-    profile_user_id: Optional[UserID] = None
+    profile_user_id: Optional[str] = None
 
     def to_dict(self) -> dict:
         if self.event_id:
-            return {"org.matrix.msc3911.restrictions": {"event_id": str(self.event_id)}}
+            return {"org.matrix.msc3911.restrictions": {"event_id": self.event_id}}
         if self.profile_user_id:
             return {
                 "org.matrix.msc3911.restrictions": {
-                    "profile_user_id": self.profile_user_id.to_string()
+                    "profile_user_id": self.profile_user_id
                 }
             }
         return {}
@@ -1172,7 +1172,7 @@ class MediaRepositoryStore(MediaRepositoryBackgroundUpdateStore):
         if row:
             event_id = row[0][0]
             # Because the UserID object can be None, the 'to_string()' method may not exist
-            profile_user_id = UserID.from_string(row[0][1]) if row[0][1] else None
+            profile_user_id = row[0][1] if row[0][1] else None
             return MediaRestrictions(event_id=event_id, profile_user_id=profile_user_id)
 
         return None

--- a/synapse/storage/databases/main/media_repository.py
+++ b/synapse/storage/databases/main/media_repository.py
@@ -82,7 +82,7 @@ class MediaRestrictions:
         if self.profile_user_id:
             return {
                 "org.matrix.msc3911.restrictions": {
-                    "profile_user_id": str(self.profile_user_id)
+                    "profile_user_id": self.profile_user_id.to_string()
                 }
             }
         return {}

--- a/tests/federation/test_federation_media.py
+++ b/tests/federation/test_federation_media.py
@@ -665,7 +665,7 @@ class FederationClientDownloadTestCase(unittest.HomeserverTestCase):
         )
         assert isinstance(restrictions, MediaRestrictions)
         assert restrictions.profile_user_id is not None
-        assert restrictions.profile_user_id.to_string() == "@bob:example.com"
+        assert restrictions.profile_user_id == "@bob:example.com"
 
     def test_downloading_remote_media_with_no_restrictions_does_not_save_to_db(
         self,

--- a/tests/rest/client/test_media.py
+++ b/tests/rest/client/test_media.py
@@ -69,7 +69,7 @@ from synapse.server import HomeServer
 from synapse.storage.databases.main.media_repository import (
     LocalMedia,
 )
-from synapse.types import JsonDict, UserID, create_requester
+from synapse.types import JsonDict, Requester, UserID, create_requester
 from synapse.util import Clock, json_encoder
 from synapse.util.stringutils import parse_and_validate_mxc_uri, random_string
 
@@ -3748,8 +3748,18 @@ class RestrictedMediaVisibilityTestCase(unittest.HomeserverTestCase):
         else:
             maybe_assert_exception = self.assertRaises(UnauthorizedRequestAPICallError)
         with maybe_assert_exception:
+            requester = Requester(
+                user=target_user,
+                access_token_id=None,
+                is_guest=False,
+                scope={"scope"},
+                shadow_banned=False,
+                device_id=None,
+                app_service=None,
+                authenticated_entity="auth",
+            )
             self.get_success_or_raise(
-                self.media_repo.is_media_visible(target_user, media_object)
+                self.media_repo.is_media_visible(requester, media_object)
             )
 
     @parameterized.expand(

--- a/tests/rest/client/test_profile.py
+++ b/tests/rest/client/test_profile.py
@@ -1013,7 +1013,7 @@ class ProfileMediaAttachmentTestCase(unittest.HomeserverTestCase):
         )
         assert restrictions is not None, str(restrictions)
         assert restrictions.event_id is None
-        assert restrictions.profile_user_id == UserID.from_string(self.user)
+        assert restrictions.profile_user_id == self.user
 
     def test_attaching_nonexistent_local_media_to_profile_fails(self) -> None:
         """
@@ -1274,7 +1274,7 @@ class ProfileMediaAttachmentTestCase(unittest.HomeserverTestCase):
         media_info = self.get_success(self.store.get_local_media(mxc_uri.media_id))
         assert media_info is not None
         assert media_info.attachments is not None
-        assert media_info.attachments.profile_user_id == UserID.from_string(self.user)
+        assert media_info.attachments.profile_user_id == self.user
 
         # Check the media was copied and attached to a member event
         events = self.get_success(
@@ -1446,7 +1446,7 @@ class ProfileMediaAttachmentReplicationTestCase(BaseMultiWorkerStreamTestCase):
         media_info = self.get_success(self.store.get_local_media(mxc_uri.media_id))
         assert media_info is not None
         assert media_info.attachments is not None
-        assert media_info.attachments.profile_user_id == UserID.from_string(self.user)
+        assert media_info.attachments.profile_user_id == self.user
 
         # Check the media was copied and attached to a member event
         events = self.get_success(

--- a/tests/storage/test_media.py
+++ b/tests/storage/test_media.py
@@ -41,11 +41,11 @@ class MediaAttachmentStorageTestCase(unittest.HomeserverTestCase):
         assert retrieved_restrictions.profile_user_id is None
 
     def test_store_and_retrieve_media_restrictions_by_profile_user_id(self) -> None:
-        user_id = UserID.from_string("@frank:test")
+        user_id = "@frank:test"
         media_id = random_string(24)
         self.get_success_or_raise(
             self.store.set_media_restricted_to_user_profile(
-                self.server_name, media_id, user_id.to_string()
+                self.server_name, media_id, user_id
             )
         )
 

--- a/tests/storage/test_media.py
+++ b/tests/storage/test_media.py
@@ -2,7 +2,6 @@ from twisted.test.proto_helpers import MemoryReactor
 
 from synapse.api.errors import SynapseError
 from synapse.server import HomeServer
-from synapse.types import UserID
 from synapse.util import Clock
 from synapse.util.stringutils import random_string
 


### PR DESCRIPTION
# Linked Media MSC3911 AP?: Media deletion on redaction [#3366](https://github.com/famedly/product-management/issues/3366)

- [x]  When an event is redacted, media attached to it should also be deleted.
- [x]  When the content of an event would be redacted (because of a redaction), the attached media should also be deleted. This should apply to local and remote media.
- [x]  We may need to support a delay for moderators, in which case downloads should be immediately restricted for normal users and still be available for moderators, then the media deleted later.