### PR TITLE
WIP: MSC3911: Handle media that are attached to redacted media - via quarantine

### DIFF
--- a/synapse/handlers/admin.py
+++ b/synapse/handlers/admin.py
@@ -504,6 +504,12 @@ class AdminHandler:
                         prev_event_ids=[event.event_id],
                         ratelimit=False,
                     )
+                    # TODO
+                    # Find all the media that was attached to the original event
+                    #  and quarantine them!
+                    await self._store.quarantine_media_by_event_id(
+                        event.event_id, requester.user.to_string()
+                    )
                 except Exception as ex:
                     logger.info(
                         "Redaction of event %s failed due to: %s", event.event_id, ex

--- a/synapse/handlers/relations.py
+++ b/synapse/handlers/relations.py
@@ -95,6 +95,7 @@ class RelationsHandler:
         self._event_handler = hs.get_event_handler()
         self._event_serializer = hs.get_event_client_serializer()
         self._event_creation_handler = hs.get_event_creation_handler()
+        self._store = hs.get_datastores().main
 
     async def get_relations(
         self,
@@ -258,6 +259,12 @@ class RelationsHandler:
                     },
                     ratelimit=False,
                 )
+                # TODO
+                # Find all the media that was attached to the original event
+                # and quarantine them!
+                await self._store.quarantine_media_by_event_id(
+                        related_event_id, requester.user.to_string()
+                    )
             except SynapseError as e:
                 logger.warning(
                     "Failed to redact event %s (related to event %s): %s",

--- a/synapse/rest/client/media.py
+++ b/synapse/rest/client/media.py
@@ -375,6 +375,11 @@ class CopyResource(RestServlet):
         if not media_info:
             raise NotFoundError()
         if media_info.quarantined_by:
+            # TODO:
+            # if the requester is moderator of the room
+            # allow download
+            # if not a moderator, return 404
+            # But do moderators need to copy quarantined media?
             raise NotFoundError()
 
         await self._validate_user_media_limit(requester, media_info)

--- a/synapse/rest/client/room.py
+++ b/synapse/rest/client/room.py
@@ -1402,7 +1402,10 @@ class RoomRedactEventRestServlet(TransactionRestServlet):
                 ) = await self.event_creation_handler.create_and_send_nonmember_event(
                     requester, event_dict, txn_id=txn_id
                 )
-
+                # TODO
+                # Find all the media that was attached to the original event
+                # and quarantine them.
+                await self._store.quarantine_media_by_event_id(event_id, requester.user.to_string())
                 if with_relations:
                     run_as_background_process(
                         "redact_related_events",

--- a/synapse/storage/databases/main/media_repository.py
+++ b/synapse/storage/databases/main/media_repository.py
@@ -34,6 +34,8 @@ from typing import (
 )
 
 import attr
+from synapse.storage.engines import PostgresEngine
+import time
 
 from synapse.api.constants import Direction
 from synapse.api.errors import Codes, SynapseError


### PR DESCRIPTION
# Linked Media MSC3911 AP?: Media deletion on redaction [#3366](https://github.com/famedly/product-management/issues/3366)
This is another way of handling attached media when the event is redacted, using quarantine.
Deletion can be handled by retention rule with `delete_quarantined_media` enabled option

- []  When an event is redacted, media attached to it should also be deleted.
- []  When the content of an event would be redacted (because of a redaction), the attached media should also be deleted. This should apply to local and remote media.
- []  We may need to support a delay for moderators, in which case downloads should be immediately restricted for normal users and still be available for moderators, then the media deleted later.

## Questions
- what endpoint will moderators use to access to the media that are attached to the redacted events?
- At the moment quarantining a media also quarantines its hash. This might cause unexpected problem.
- maybe we can introduce the option to only redact the media not its hash

The quarantined media will be deleted automatically  