### PR TITLE
DONOTMERGE: bump default room version to 11 for complement testing

### DIFF
--- a/docker/complement/conf/workers-shared-extra.yaml.j2
+++ b/docker/complement/conf/workers-shared-extra.yaml.j2
@@ -163,5 +163,6 @@ caches:
 room_list_publication_rules:
   - action: allow
 
+default_room_version: "11"
 
 {% include "shared-orig.yaml.j2" %}

--- a/synapse/config/server.py
+++ b/synapse/config/server.py
@@ -175,7 +175,7 @@ DEFAULT_IP_RANGE_BLOCKLIST = [
     "fec0::/10",
 ]
 
-DEFAULT_ROOM_VERSION = "10"
+DEFAULT_ROOM_VERSION = "11"
 
 ROOM_COMPLEXITY_TOO_GREAT = (
     "Your homeserver is unable to join rooms this large or complex. "


### PR DESCRIPTION
This is branch named the same as the complement test, so it will run that change here and see if it works